### PR TITLE
Add mozilla.adml for german language

### DIFF
--- a/windows/de-DE/mozilla.adml
+++ b/windows/de-DE/mozilla.adml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<policyDefinitionResources revision="1.0" schemaVersion="1.0">
+  <displayName/>
+  <description/>
+  <resources>
+    <stringTable>
+      <string id="mozilla">Mozilla</string>
+    </stringTable>
+  </resources>
+</policyDefinitionResources>


### PR DESCRIPTION
Add the mozilla.adml to the german directory to avoid errors with missing translation.