### PR TITLE
Additional Bookmark Policies

### DIFF
--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -585,7 +585,8 @@
         <list id="HomepageAdditional" key="Software\Policies\Mozilla\Firefox\Homepage\Additional" valuePrefix=""/>
       </elements>
     </policy>
-    <policy name="Bookmark1" class="Both" displayName="$(string.Bookmark1)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\1" presentation="$(presentation.Bookmark)" >
+    </policy>
+    <policy name="Bookmark01" class="Both" displayName="$(string.Bookmark01)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\1" presentation="$(presentation.Bookmark)" >
       <parentCategory ref="Bookmarks" />
       <supportedOn ref="SUPPORTED_FF60" />
       <elements >
@@ -607,7 +608,7 @@
         </enum>
       </elements>
     </policy>
-    <policy name="Bookmark2" class="Both" displayName="$(string.Bookmark2)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\2" presentation="$(presentation.Bookmark)" >
+    <policy name="Bookmark02" class="Both" displayName="$(string.Bookmark02)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\12" presentation="$(presentation.Bookmark)" >
       <parentCategory ref="Bookmarks" />
       <supportedOn ref="SUPPORTED_FF60" />
       <elements >
@@ -629,7 +630,7 @@
         </enum>
       </elements>
     </policy>
-    <policy name="Bookmark3" class="Both" displayName="$(string.Bookmark3)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\3" presentation="$(presentation.Bookmark)" >
+    <policy name="Bookmark03" class="Both" displayName="$(string.Bookmark03)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\13" presentation="$(presentation.Bookmark)" >
       <parentCategory ref="Bookmarks" />
       <supportedOn ref="SUPPORTED_FF60" />
       <elements >
@@ -651,7 +652,7 @@
         </enum>
       </elements>
     </policy>
-    <policy name="Bookmark4" class="Both" displayName="$(string.Bookmark4)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\4" presentation="$(presentation.Bookmark)" >
+    <policy name="Bookmark04" class="Both" displayName="$(string.Bookmark04)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\14" presentation="$(presentation.Bookmark)" >
       <parentCategory ref="Bookmarks" />
       <supportedOn ref="SUPPORTED_FF60" />
       <elements >
@@ -673,7 +674,997 @@
         </enum>
       </elements>
     </policy>
-    <policy name="Bookmark5" class="Both" displayName="$(string.Bookmark5)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\5" presentation="$(presentation.Bookmark)" >
+    <policy name="Bookmark05" class="Both" displayName="$(string.Bookmark05)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\15" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark06" class="Both" displayName="$(string.Bookmark06)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\16" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark07" class="Both" displayName="$(string.Bookmark07)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\17" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark08" class="Both" displayName="$(string.Bookmark08)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\18" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark09" class="Both" displayName="$(string.Bookmark09)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\19" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark10" class="Both" displayName="$(string.Bookmark10)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\20" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark11" class="Both" displayName="$(string.Bookmark11)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\21" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark12" class="Both" displayName="$(string.Bookmark12)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\22" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark13" class="Both" displayName="$(string.Bookmark13)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\23" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark14" class="Both" displayName="$(string.Bookmark14)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\24" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark15" class="Both" displayName="$(string.Bookmark15)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\25" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark16" class="Both" displayName="$(string.Bookmark16)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\26" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark17" class="Both" displayName="$(string.Bookmark17)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\27" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark18" class="Both" displayName="$(string.Bookmark18)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\28" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark19" class="Both" displayName="$(string.Bookmark19)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\29" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark20" class="Both" displayName="$(string.Bookmark20)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\30" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark21" class="Both" displayName="$(string.Bookmark21)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\31" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark22" class="Both" displayName="$(string.Bookmark22)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\32" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark23" class="Both" displayName="$(string.Bookmark23)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\33" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark24" class="Both" displayName="$(string.Bookmark24)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\34" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark25" class="Both" displayName="$(string.Bookmark25)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\35" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark26" class="Both" displayName="$(string.Bookmark26)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\36" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark27" class="Both" displayName="$(string.Bookmark27)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\37" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark28" class="Both" displayName="$(string.Bookmark28)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\38" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark29" class="Both" displayName="$(string.Bookmark29)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\39" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark30" class="Both" displayName="$(string.Bookmark30)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\40" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark31" class="Both" displayName="$(string.Bookmark31)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\41" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark32" class="Both" displayName="$(string.Bookmark32)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\42" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark33" class="Both" displayName="$(string.Bookmark33)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\43" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark34" class="Both" displayName="$(string.Bookmark34)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\44" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark35" class="Both" displayName="$(string.Bookmark35)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\45" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark36" class="Both" displayName="$(string.Bookmark36)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\46" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark37" class="Both" displayName="$(string.Bookmark37)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\47" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark38" class="Both" displayName="$(string.Bookmark38)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\48" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark39" class="Both" displayName="$(string.Bookmark39)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\49" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark40" class="Both" displayName="$(string.Bookmark40)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\50" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark41" class="Both" displayName="$(string.Bookmark41)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\51" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark42" class="Both" displayName="$(string.Bookmark42)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\52" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark43" class="Both" displayName="$(string.Bookmark43)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\53" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark44" class="Both" displayName="$(string.Bookmark44)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\54" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark45" class="Both" displayName="$(string.Bookmark45)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\55" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark46" class="Both" displayName="$(string.Bookmark46)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\56" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark47" class="Both" displayName="$(string.Bookmark47)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\57" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark48" class="Both" displayName="$(string.Bookmark48)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\58" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark49" class="Both" displayName="$(string.Bookmark49)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\59" presentation="$(presentation.Bookmark)" >
+      <parentCategory ref="Bookmarks" />
+      <supportedOn ref="SUPPORTED_FF60" />
+      <elements >
+        <text id="BookmarkTitle" valueName="Title" required="true" />
+        <text id="BookmarkURL" valueName="URL" required="true" />
+        <text id="BookmarkFolder" valueName="Folder" />
+        <text id="BookmarkFavicon" valueName="Favicon" />
+        <enum id="BookmarkPlacement" valueName="Placement">
+          <item displayName="$(string.BookmarkPlacementToolbar)">
+            <value>
+              <string>toolbar</string>
+            </value>
+          </item>
+          <item displayName="$(string.BookmarkPlacementMenu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+	<policy name="Bookmark50" class="Both" displayName="$(string.Bookmark50)" explainText="$(string.Bookmark_Explain)" key="Software\Policies\Mozilla\Firefox\Bookmarks\60" presentation="$(presentation.Bookmark)" >
       <parentCategory ref="Bookmarks" />
       <supportedOn ref="SUPPORTED_FF60" />
       <elements >


### PR DESCRIPTION
Previously there were only 5 bookmark policies, I added 45 more to bring it to 50.

Note that I changed the registry "key" values to be 10 greater than the bookmark number after the first bookmark policy.
I did this as a workaround to an issue I noticed, where the registry numbering was sorted alphabetically (1, 11, 12, ..., 2, 21, 22, ...) rather than numerically (1, 2, 3, ... , 10, 11, 12).

I also prefixed the first nine policy names with zero (01, 02, 03, 04, ...) to workaround the group policy editor sorting alphabetically rather than numerically.