### PR TITLE
Update firefox.admx

### DIFF
--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -4,7 +4,7 @@
     <target prefix="firefox" namespace="Mozilla.Policies.Firefox"/>
     <using prefix="Mozilla" namespace="Mozilla.Policies"/>
   </policyNamespaces>
-  <resources minRequiredRevision="1.1"/>
+  <resources minRequiredRevision="1.2"/>
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_WINXPSP2" displayName="$(string.SUPPORTED_WINXPSP2)"/>


### PR DESCRIPTION
Bump minimum required version to 1.2 - fixes error in RSOP regarding version mismatch