### PR TITLE
Clarify defaults write command.

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -26,7 +26,7 @@ which would be set in the plist file like this:
     <string>http://example.com</string>
   </dict>
 ```
-As correctly writing nested values with the `defaults` command can be hard, Firefox also supports writing nested values by separating them with `__`, like this:
+Correctly writing the nested value with the `defaults` command can be hard, so you can flatten the keys by separating them with `__`, like this:
 ```bash
 sudo defaults write /Library/Preferences/org.mozilla.firefox Homepage__URL -string "http://example.com"
 ```

--- a/mac/README.md
+++ b/mac/README.md
@@ -26,11 +26,11 @@ which would be set in the plist file like this:
     <string>http://example.com</string>
   </dict>
 ```
-can be set via the command line like this:
-```
-defaults write org.mozilla.firefox Homepage__URL -string "http://example.com"
+As correctly writing nested values with the `defaults` command can be hard, Firefox also supports writing nested values by separating them with `__`, like this:
+```bash
+sudo defaults write /Library/Preferences/org.mozilla.firefox Homepage__URL -string "http://example.com"
 ```
 Before any command line policies will work, you need to enable policies like this:
-```
-defaults write org.mozilla.firefox EnterprisePoliciesEnabled -bool TRUE
+```bash
+sudo defaults write /Library/Preferences/org.mozilla.firefox EnterprisePoliciesEnabled -bool TRUE
 ```

--- a/mac/README.md
+++ b/mac/README.md
@@ -9,7 +9,7 @@ https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.
 If you want to set specific options from the command line, we also provide flattened shortcuts to any item that is nested in the plist file.
 
 For example, this policy:
-```
+```json
 {
   "policies": {
     "Homepage": {
@@ -19,7 +19,7 @@ For example, this policy:
 }
 ```
 which would be set in the plist file like this:
-```
+```plist
   <key>Homepage</key>
   <dict>
     <key>URL</key>


### PR DESCRIPTION
Changed the example to defaults write to the system preferences, rather than the user's. Also adds (barely noticeable) syntax highlighting.