### PR TITLE
Added keys to FlashPlugin dict that were missing

### DIFF
--- a/mac/org.mozilla.firefox.plist
+++ b/mac/org.mozilla.firefox.plist
@@ -181,6 +181,10 @@
 		<array>
 			<string>https://www.example.org</string>
 		</array>
+		<key>Default</key>
+		<true/>
+		<key>Locked</key>
+		<true/>
 	</dict>
 	<key>HardwareAcceleration</key>
 	<false/>


### PR DESCRIPTION
Default and Locked are both keys that can hold boolean values according to main Policy Template.