### PR TITLE
Add RejectTracker key to Cookies dict

### DIFF
--- a/mac/org.mozilla.firefox.plist
+++ b/mac/org.mozilla.firefox.plist
@@ -92,6 +92,8 @@
 		<string>never</string>
 		<key>ExpireAtSessionEnd</key>
 		<true/>
+		<key>RejectTracker</key>
+		<true/>		
 		<key>Locked</key>
 		<true/>
 	</dict>


### PR DESCRIPTION
https://github.com/mozilla/policy-templates#cookies currently states that `RejectTracker` is a key that takes a boolean value. Adding this to plist template.