### PR TITLE
Add support for SSLVersionMin and SSLVersionMax

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,4 +630,23 @@ This policy allows you to add PKCS #11 Modules
     }
   }
 }
+### SSLVersionMin
+This policy allows you to set the minimum TLS version.
+```
+{
+  "policies": {
+    "SSSLVersionMin": ["tls1", "tls1.1", "tls1.2",. "tls1.3"]
+  }
+}
+
+```
+### SSLVersionMax
+This policy allows you to set the maximum TLS version.
+```
+{
+  "policies": {
+    "SSSLVersionMax": ["tls1", "tls1.1", "tls1.2",. "tls1.3"]
+  }
+}
+
 ```

--- a/mac/org.mozilla.firefox.plist
+++ b/mac/org.mozilla.firefox.plist
@@ -335,5 +335,9 @@
 		<key>NAME_OF_DEVICE</key>
 		<string>PATH_TO_LIBRARY_FOR_DEVICE</string>
 	</dict>
+	<key>SSLMinVersion</key>
+	<string>tls1.2</string>
+	<key>SSLMaxVersion</key>
+	<string>tls1.3</string>
 </dict>
 </plist>

--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources revision="1.3" schemaVersion="1.0" >
+<policyDefinitionResources revision="1.4" schemaVersion="1.0" >
   <displayName/>
   <description/>
   <resources >
@@ -9,6 +9,7 @@
       <string id="SUPPORTED_FF62">Firefox 62 oder höher, Firefox 60.2 ESR oder höher</string>
       <string id="SUPPORTED_FF63">Firefox 63 oder höher</string>
       <string id="SUPPORTED_FF64">Firefox 64 oder höher, Firefox 60.4 ESR oder höher</string>
+      <string id="SUPPORTED_FF66">Firefox 66 oder höher, Firefox 60.6 ESR oder höher</string>
       <string id="SUPPORTED_FF60ESR">Firefox 60 ESR oder höher</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Berechtigungen</string>
@@ -475,6 +476,18 @@ Wenn Sie die Richtlinieneinstellung deaktivieren oder nicht konfigurieren, könn
       <string id="SearchEngines_Remove_Explain">If this policy is enabled, you can specify the names of engines to be removed or hidden.
 
 If this policy is disabled or not configured, search engines will not be removed or hidden.</string>
+      <string id="SSLVersionMin">Minimum SSL version enabled</string>
+      <string id="SSLVersionMin_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions less than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.0.</string>
+      <string id="SSLVersionMax">Maximum SSL version enabled</string>
+      <string id="SSLVersionMax_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions greater than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a maximum of TLS 1.3.</string>
+      <string id="TLS1">TLS 1.0</string>
+      <string id="TLS1_1">TLS 1.1</string>
+      <string id="TLS1_2">TLS 1.2</string>
+      <string id="TLS1_3">TLS 1.3</string>
     </stringTable>
     <presentationTable>
       <presentation id="AppUpdateURL">
@@ -625,6 +638,9 @@ If this policy is disabled or not configured, search engines will not be removed
         </textBox>
         <checkBox refId="DNSOverHTTPSEnabled">Enable DNS over HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Don't allow DNS over HTTPS preferences to be changed.</checkBox>
+      </presentation>
+      <presentation id="SSLVersion">
+        <dropdownList refId="SSLVersion"/>
       </presentation>
     </presentationTable>
   </resources>

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources revision="1.3" schemaVersion="1.0" >
+<policyDefinitionResources revision="1.4" schemaVersion="1.0" >
   <displayName/>
   <description/>
   <resources >
@@ -9,6 +9,7 @@
       <string id="SUPPORTED_FF62">Firefox 62 or later, Firefox 60.2 ESR or later</string>
       <string id="SUPPORTED_FF63">Firefox 63 or later</string>
       <string id="SUPPORTED_FF64">Firefox 64 or later, Firefox 60.4 ESR or later</string>
+      <string id="SUPPORTED_FF66">Firefox 66 or later, Firefox 60.6 ESR or later</string>
       <string id="SUPPORTED_FF60ESR">Firefox 60 ESR or later</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Permissions</string>
@@ -475,6 +476,18 @@ If this policy is disabled or not configured, search engines can be installed fr
       <string id="SearchEngines_Remove_Explain">If this policy is enabled, you can specify the names of engines to be removed or hidden.
 
 If this policy is disabled or not configured, search engines will not be removed or hidden.</string>
+      <string id="SSLVersionMin">Minimum SSL version enabled</string>
+      <string id="SSLVersionMin_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions less than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.0.</string>
+      <string id="SSLVersionMax">Maximum SSL version enabled</string>
+      <string id="SSLVersionMax_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions greater than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a maximum of TLS 1.3.</string>
+      <string id="TLS1">TLS 1.0</string>
+      <string id="TLS1_1">TLS 1.1</string>
+      <string id="TLS1_2">TLS 1.2</string>
+      <string id="TLS1_3">TLS 1.3</string>
     </stringTable>
     <presentationTable>
       <presentation id="AppUpdateURL">
@@ -625,6 +638,9 @@ If this policy is disabled or not configured, search engines will not be removed
         </textBox>
         <checkBox refId="DNSOverHTTPSEnabled">Enable DNS over HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Don't allow DNS over HTTPS preferences to be changed.</checkBox>
+      </presentation>
+      <presentation id="SSLVersion">
+        <dropdownList refId="SSLVersion"/>
       </presentation>
     </presentationTable>
   </resources>

--- a/windows/es-ES/firefox.adml
+++ b/windows/es-ES/firefox.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources revision="1.3" schemaVersion="1.0" >
+<policyDefinitionResources revision="1.4" schemaVersion="1.0" >
   <displayName/>
   <description/>
   <resources >
@@ -9,6 +9,7 @@
       <string id="SUPPORTED_FF62">Firefox 62 o posterior, Firefox 60.2 ESR o posterior</string>
       <string id="SUPPORTED_FF63">Firefox 63 o posterior</string>
       <string id="SUPPORTED_FF64">Firefox 64 o posterior, Firefox 60.4 ESR o posterior</string>
+      <string id="SUPPORTED_FF66">Firefox 66 o posterior, Firefox 60.6 ESR o posterior</string>
       <string id="SUPPORTED_FF60ESR">Firefox 60 ESR o posterior</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Permisos</string>
@@ -475,6 +476,18 @@ Si esta política está deshabilitada o no está configurada, los motores de bú
       <string id="SearchEngines_Remove_Explain">Si esta política está habilitada, puede especificar los nombres de los motores que se borrarán u ocultarán.
 
 Si esta política está deshabilitada o no configurada, los motores de búsqueda no se borrarán ni se ocultarán.</string>
+      <string id="SSLVersionMin">Minimum SSL version enabled</string>
+      <string id="SSLVersionMin_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions less than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.0.</string>
+      <string id="SSLVersionMax">Maximum SSL version enabled</string>
+      <string id="SSLVersionMax_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions greater than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a maximum of TLS 1.3.</string>
+      <string id="TLS1">TLS 1.0</string>
+      <string id="TLS1_1">TLS 1.1</string>
+      <string id="TLS1_2">TLS 1.2</string>
+      <string id="TLS1_3">TLS 1.3</string>
     </stringTable>
     <presentationTable>
       <presentation id="AppUpdateURL">
@@ -625,6 +638,9 @@ Si esta política está deshabilitada o no configurada, los motores de búsqueda
         </textBox>
         <checkBox refId="DNSOverHTTPSEnabled">Habilitar DNS sobre HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">No permitir que se cambien las preferencias de DNS sobre HTTPS.</checkBox>
+      </presentation>
+      <presentation id="SSLVersion">
+        <dropdownList refId="SSLVersion"/>
       </presentation>
     </presentationTable>
   </resources>

--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<policyDefinitions revision="1.3" schemaVersion="1.0">
+<policyDefinitions revision="1.4" schemaVersion="1.0">
   <policyNamespaces>
     <target prefix="firefox" namespace="Mozilla.Policies.Firefox"/>
     <using prefix="Mozilla" namespace="Mozilla.Policies"/>
   </policyNamespaces>
-  <resources minRequiredRevision="1.3"/>
+  <resources minRequiredRevision="1.4"/>
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_WINXPSP2" displayName="$(string.SUPPORTED_WINXPSP2)"/>
@@ -12,6 +12,8 @@
       <definition name="SUPPORTED_FF60ESR" displayName="$(string.SUPPORTED_FF60ESR)"/>
       <definition name="SUPPORTED_FF62" displayName="$(string.SUPPORTED_FF62)"/>
       <definition name="SUPPORTED_FF63" displayName="$(string.SUPPORTED_FF63)"/>
+      <definition name="SUPPORTED_FF64" displayName="$(string.SUPPORTED_FF64)"/>
+      <definition name="SUPPORTED_FF66" displayName="$(string.SUPPORTED_FF66)"/>
     </definitions>
   </supportedOn>
   <categories>
@@ -2235,5 +2237,62 @@
         <list id="RequestedLocales" key="Software\Policies\Mozilla\Firefox\RequestedLocales" valuePrefix=""/>
       </elements>
     </policy>
+    <policy name="SSLVersionMin" class="Both" displayName="$(string.SSLVersionMin)" explainText="$(string.SSLVersionMin_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.SSLVersion)" >
+      <parentCategory ref="firefox" />
+      <supportedOn ref="SUPPORTED_FF66" />
+      <elements >
+        <enum id="SSLVersion" valueName="SSLVersionMin">
+          <item displayName="$(string.TLS1)">
+            <value>
+              <string>tls1</string>
+            </value>
+          </item>
+          <item displayName="$(string.TLS1_1)">
+            <value>
+              <string>tls1.1</string>
+            </value>
+          </item>
+          <item displayName="$(string.TLS1_2)">
+            <value>
+              <string>tls1.2</string>
+            </value>
+          </item>
+          <item displayName="$(string.TLS1_3)">
+            <value>
+              <string>tls1.3</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+    <policy name="SSLVersionMax" class="Both" displayName="$(string.SSLVersionMax)" explainText="$(string.SSLVersionMax_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.SSLVersion)" >
+      <parentCategory ref="firefox" />
+      <supportedOn ref="SUPPORTED_FF66" />
+      <elements >
+        <enum id="SSLVersion" valueName="SSLVersionMax">
+          <item displayName="$(string.TLS1)">
+            <value>
+              <string>tls1</string>
+            </value>
+          </item>
+          <item displayName="$(string.TLS1_1)">
+            <value>
+              <string>tls1.1</string>
+            </value>
+          </item>
+          <item displayName="$(string.TLS1_2)">
+            <value>
+              <string>tls1.2</string>
+            </value>
+          </item>
+          <item displayName="$(string.TLS1_3)">
+            <value>
+              <string>tls1.3</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
   </policies>
 </policyDefinitions>
+

--- a/windows/fr-FR/firefox.adml
+++ b/windows/fr-FR/firefox.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources revision="1.3" schemaVersion="1.0" >
+<policyDefinitionResources revision="1.4" schemaVersion="1.0" >
   <displayName/>
   <description/>
   <resources >
@@ -9,6 +9,7 @@
       <string id="SUPPORTED_FF62">Firefox 62 ou superieur, Firefox 60.2 ESR ou superieur</string>
       <string id="SUPPORTED_FF63">Firefox 63 ou superieur</string>
       <string id="SUPPORTED_FF64">Firefox 64 ou superieur, Firefox 60.4 ESR ou superieur</string>
+      <string id="SUPPORTED_FF66">Firefox 66 ou superieur, Firefox 60.6 ESR ou superieur</string>
       <string id="SUPPORTED_FF60ESR">Firefox 60 ESR ou superieur</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Permissions</string>
@@ -475,6 +476,18 @@ Si cette stratégie est désactivée ou non configurée, les moteurs de recherch
       <string id="SearchEngines_Remove_Explain">Si cette stratégie est activée, vous pouvez spécifier les noms des moteurs à supprimer ou à masquer.
 
 Si cette stratégie est désactivée ou non configurée, les moteurs de recherche ne seront ni supprimés ni masqués.</string>
+      <string id="SSLVersionMin">Minimum SSL version enabled</string>
+      <string id="SSLVersionMin_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions less than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.0.</string>
+      <string id="SSLVersionMax">Maximum SSL version enabled</string>
+      <string id="SSLVersionMax_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions greater than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a maximum of TLS 1.3.</string>
+      <string id="TLS1">TLS 1.0</string>
+      <string id="TLS1_1">TLS 1.1</string>
+      <string id="TLS1_2">TLS 1.2</string>
+      <string id="TLS1_3">TLS 1.3</string>
     </stringTable>
     <presentationTable>
       <presentation id="AppUpdateURL">
@@ -625,6 +638,9 @@ Si cette stratégie est désactivée ou non configurée, les moteurs de recherch
         </textBox>
         <checkBox refId="DNSOverHTTPSEnabled">Activer DNS sur HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Ne pas autoriser la modification des préférences DNS sur HTTPS.</checkBox>
+      </presentation>
+      <presentation id="SSLVersion">
+        <dropdownList refId="SSLVersion"/>
       </presentation>
     </presentationTable>
   </resources>

--- a/windows/it-IT/firefox.adml
+++ b/windows/it-IT/firefox.adml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources revision="1.3" schemaVersion="1.0" >
+<policyDefinitionResources revision="1.4" schemaVersion="1.0" >
   <displayName/>
   <description/>
   <resources >
@@ -9,6 +9,7 @@
       <string id="SUPPORTED_FF62">Firefox 62 o versione successiva, Firefox 60.2 ESR o versione successiva</string>
       <string id="SUPPORTED_FF63">Firefox 63 o versione successiva</string>
       <string id="SUPPORTED_FF64">Firefox 64 o versione successiva, Firefox 60.4 ESR o versione successiva</string>
+      <string id="SUPPORTED_FF66">Firefox 66 o versione successiva, Firefox 60.6 ESR o versione successiva</string>
       <string id="SUPPORTED_FF60ESR">Firefox 60 ESR o versione successiva</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Permessi</string>
@@ -475,6 +476,18 @@ Se questo criterio è disabilitato o non configurato, i motori di ricerca potran
       <string id="SearchEngines_Remove_Explain">Se questo criterio è abilitato, è possibile specificare i nomi dei motori di ricerca da rimuovere o nascondere.
 
 Se questo criterio è disabilitato o non configurato, i motori di ricerca non saranno né rimossi né nascosti.</string>
+      <string id="SSLVersionMin">Minimum SSL version enabled</string>
+      <string id="SSLVersionMin_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions less than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.0.</string>
+      <string id="SSLVersionMax">Maximum SSL version enabled</string>
+      <string id="SSLVersionMax_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions greater than the value specified.
+
+If this policy is disabled or not configured, Firefox defaults to a maximum of TLS 1.3.</string>
+      <string id="TLS1">TLS 1.0</string>
+      <string id="TLS1_1">TLS 1.1</string>
+      <string id="TLS1_2">TLS 1.2</string>
+      <string id="TLS1_3">TLS 1.3</string>
     </stringTable>
     <presentationTable>
       <presentation id="AppUpdateURL">
@@ -625,6 +638,9 @@ Se questo criterio è disabilitato o non configurato, i motori di ricerca non sa
         </textBox>
         <checkBox refId="DNSOverHTTPSEnabled">Abilita DNS su HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Non consentire la modifica delle preferenze relative a DNS su HTTPS.</checkBox>
+      </presentation>
+      <presentation id="SSLVersion">
+        <dropdownList refId="SSLVersion"/>
       </presentation>
     </presentationTable>
   </resources>


### PR DESCRIPTION
This adds support for the new SSLVersionMin and SSLVersionMax policies in Firefox 66.

There were no other policies added for Firefox 66.