### PR TITLE
Fix plist highlighting

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -19,12 +19,12 @@ For example, this policy:
 }
 ```
 which would be set in the plist file like this:
-```plist
-  <key>Homepage</key>
-  <dict>
-    <key>URL</key>
-    <string>http://example.com</string>
-  </dict>
+```xml
+<key>Homepage</key>
+<dict>
+  <key>URL</key>
+  <string>http://example.com</string>
+</dict>
 ```
 Correctly writing the nested value with the `defaults` command can be hard, so you can flatten the keys by separating them with `__`, like this:
 ```bash


### PR DESCRIPTION
Previous the plist example had a red background. Probably because this isn't a valid plist and more a part of a plist. Using xml highlighting fixes this issue.