### PR TITLE
Correct the name of the registry key used for Handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2478,7 +2478,7 @@ Within each handler type, you specify the given mimeType/extension/scheme as a k
 
 #### Windows (GPO)
 ```
-Software\Policies\Mozilla\Firefox\ExtensionSettings (REG_MULTI_SZ) =
+Software\Policies\Mozilla\Firefox\Handlers (REG_MULTI_SZ) =
 {
   "mimeTypes": {
     "application/msword": {


### PR DESCRIPTION
I was attempting to implement this policy at my organization when I discovered through trial and error that the registry key path listed was incorrect. This PR updates the README documentation to list the correct registry key name for management of Handlers.