### PR TITLE
Fix SearchBar Intune data id

### DIFF
--- a/README.md
+++ b/README.md
@@ -4883,7 +4883,7 @@ OMA-URI:
 Value (string):
 ```
 <enabled/>
-<data id="Permissions" value="unified | separate"/>
+<data id="SearchBar" value="unified | separate"/>
 ```
 #### macOS
 ```


### PR DESCRIPTION
The SearchBar data id name is wrong. It is referenced in the ADMX template as <enum id="SearchBar" valueName="SearchBar"> and not Permissions as shown in the readme.