### PR TITLE
ShowHomeButton OMA-URI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5379,7 +5379,7 @@ Software\Policies\Mozilla\Firefox\ShowHomeButton = 0x1 | 0x0
 #### Windows (Intune)
 OMA-URI:
 ```
-./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox/ShowHomeButton
+./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox~Homepage/Homepage_ShowHomeButton
 ```
 Value (string):
 ```


### PR DESCRIPTION
It appears that this OMA-URI has been moved for the ShowHomeButton
https://github.com/mozilla/policy-templates/blob/master/windows/firefox.admx#L1460