### PR TITLE
Add quotation marks to values of "DisplayBookmarksToolbar" in policies.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -2088,7 +2088,7 @@ Value (string):
 ```
 {
   "policies": {
-    "DisplayBookmarksToolbar": always | never | newtab
+    "DisplayBookmarksToolbar": "always" | "never" | "newtab"
   }
 }
 ```


### PR DESCRIPTION
The values in the policies.json section of the new DisplayBookmarksToolbar policy are missing the required quotation marks