### PR TITLE
[SSL Version policies] Update description, docs and add default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -5656,7 +5656,7 @@ Value (string):
 ```
 ### SSLVersionMax
 
-Set and lock the maximum version of TLS.
+Set and lock the maximum version of TLS. (Firefox defaults to a maximum of TLS 1.3.)
 
 **Compatibility:** Firefox 66, Firefox ESR 60.6\
 **CCK2 Equivalent:** N/A\
@@ -5694,7 +5694,7 @@ Value (string):
 ```
 ### SSLVersionMin
 
-Set and lock the minimum version of TLS.
+Set and lock the minimum version of TLS. (Firefox defaults to a minimum of TLS 1.2.)
 
 **Compatibility:** Firefox 66, Firefox ESR 60.6\
 **CCK2 Equivalent:** N/A\

--- a/docs/index.md
+++ b/docs/index.md
@@ -5646,7 +5646,7 @@ Value (string):
 ```
 ### SSLVersionMax
 
-Set and lock the maximum version of TLS.
+Set and lock the maximum version of TLS. (Firefox defaults to a maximum of TLS 1.3.)
 
 **Compatibility:** Firefox 66, Firefox ESR 60.6\
 **CCK2 Equivalent:** N/A\
@@ -5684,7 +5684,7 @@ Value (string):
 ```
 ### SSLVersionMin
 
-Set and lock the minimum version of TLS.
+Set and lock the minimum version of TLS. (Firefox defaults to a minimum of TLS 1.2.)
 
 **Compatibility:** Firefox 66, Firefox ESR 60.6\
 **CCK2 Equivalent:** N/A\

--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -1269,8 +1269,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences (E
         <checkBox refId="DNSOverHTTPSEnabled">DNS über HTTPS aktivieren.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Änderungen an den DNS-über-HTTPS Einstellungen nicht erlauben.</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>Title:</text>

--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -810,7 +810,7 @@ Wenn Sie die Richtlinieneinstellung nicht konfigurieren, werden Suchvorschläge 
       <string id="SSLVersionMin">Minimale SSL-Version</string>
       <string id="SSLVersionMin_Explain">Wenn Sie die Richtlinieneinstellung aktivieren, Firefox wird keine SSL/TLS-Version unter der angegebenen Version verwenden.
 
-Wenn Sie die Richtlinieneinstellung deaktivieren oder nicht konfigurieren, verwendet Firefox die Standardeinstellung von TLS 1.0.</string>
+Wenn Sie die Richtlinieneinstellung deaktivieren oder nicht konfigurieren, verwendet Firefox die Standardeinstellung von TLS 1.2.</string>
       <string id="SSLVersionMax">Maximale SSL-Version</string>
       <string id="SSLVersionMax_Explain">Wenn Sie die Richtlinieneinstellung aktivieren, Firefox wird keine höhere SSL/TLS-Version als der angegebenen Version verwenden.
 

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -810,7 +810,7 @@ If this policy is not configured, search suggestions will be enabled, but the us
       <string id="SSLVersionMin">Minimum SSL version enabled</string>
       <string id="SSLVersionMin_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions less than the value specified.
 
-If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.0.</string>
+If this policy is disabled or not configured, Firefox defaults to a minimum of TLS 1.2.</string>
       <string id="SSLVersionMax">Maximum SSL version enabled</string>
       <string id="SSLVersionMax_Explain">If this policy is enabled, Firefox will not use SSL/TLS versions greater than the value specified.
 

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -1270,7 +1270,7 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
       <presentation id="SSLVersionMin">
         <dropdownList refId="SSLVersion" defaultItem="2"/>
       </presentation>
-	  <presentation id="SSLVersionMax">
+      <presentation id="SSLVersionMax">
         <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -1267,8 +1267,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
         <checkBox refId="DNSOverHTTPSEnabled">Enable DNS over HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Don't allow DNS over HTTPS preferences to be changed.</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+	  <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>Title:</text>

--- a/windows/es-ES/firefox.adml
+++ b/windows/es-ES/firefox.adml
@@ -1269,8 +1269,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</s
         <checkBox refId="DNSOverHTTPSEnabled">Habilitar DNS mediante HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">No permitir que se cambien las preferencias de DNS mediante HTTPS.</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>Título:</text>

--- a/windows/es-ES/firefox.adml
+++ b/windows/es-ES/firefox.adml
@@ -812,7 +812,7 @@ Si esta política no está configurada, las sugerencias de búsqueda se habilita
       <string id="SSLVersionMin">Versión mínima de SSL habilitada</string>
       <string id="SSLVersionMin_Explain">Si esta política está habilitada, Firefox no utilizará versiones SSL/TLS inferiores al valor especificado.
 
-Si esta política está deshabilitada o no está configurada, Firefox establecerá de manera predeterminada un mínimo de TLS 1.0.</string>
+Si esta política está deshabilitada o no está configurada, Firefox establecerá de manera predeterminada un mínimo de TLS 1.2.</string>
       <string id="SSLVersionMax">Versión máxima de SSL habilitada</string>
       <string id="SSLVersionMax_Explain">Si esta política está habilitada, Firefox no utilizará versiones SSL/TLS superiores al valor especificado.
 

--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -2885,7 +2885,7 @@
         <text id="Preferences_String" valueName="RequestedLocales"/>
       </elements>
     </policy>
-    <policy name="SSLVersionMin" class="Both" displayName="$(string.SSLVersionMin)" explainText="$(string.SSLVersionMin_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.SSLVersion)" >
+    <policy name="SSLVersionMin" class="Both" displayName="$(string.SSLVersionMin)" explainText="$(string.SSLVersionMin_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.SSLVersionMin)" >
       <parentCategory ref="firefox" />
       <supportedOn ref="SUPPORTED_FF66" />
       <elements>
@@ -2913,7 +2913,7 @@
         </enum>
       </elements>
     </policy>
-    <policy name="SSLVersionMax" class="Both" displayName="$(string.SSLVersionMax)" explainText="$(string.SSLVersionMax_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.SSLVersion)" >
+    <policy name="SSLVersionMax" class="Both" displayName="$(string.SSLVersionMax)" explainText="$(string.SSLVersionMax_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.SSLVersionMax)" >
       <parentCategory ref="firefox" />
       <supportedOn ref="SUPPORTED_FF66" />
       <elements>

--- a/windows/fr-FR/firefox.adml
+++ b/windows/fr-FR/firefox.adml
@@ -811,7 +811,7 @@ Si cette stratégie n'est pas configurée, les suggestions de recherche seront a
       <string id="SSLVersionMin">Version SSL minimum utilisée</string>
       <string id="SSLVersionMin_Explain">Si cette stratégie est activée, Firefox n'utilisera pas les versions SSL / TLS inférieures à la valeur spécifiée.
 
-Si cette stratégie est désactivée ou non configurée, Firefox utilise par défaut TLS 1.0.</string>
+Si cette stratégie est désactivée ou non configurée, Firefox utilise par défaut TLS 1.2.</string>
       <string id="SSLVersionMax">Version SSL maximum utilisée</string>
       <string id="SSLVersionMax_Explain">Si cette stratégie est activée, Firefox n'utilisera pas les versions SSL / TLS supérieures à la valeur spécifiée.
 

--- a/windows/fr-FR/firefox.adml
+++ b/windows/fr-FR/firefox.adml
@@ -1268,8 +1268,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</s
         <checkBox refId="DNSOverHTTPSEnabled">Activer DNS sur HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Ne pas autoriser la modification des préférences DNS sur HTTPS.</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>Title:</text>

--- a/windows/it-IT/firefox.adml
+++ b/windows/it-IT/firefox.adml
@@ -1270,8 +1270,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</s
         <checkBox refId="DNSOverHTTPSEnabled">Abilita DNS su HTTPS.</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">Non consentire la modifica delle preferenze relative a DNS su HTTPS.</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>Titolo:</text>

--- a/windows/it-IT/firefox.adml
+++ b/windows/it-IT/firefox.adml
@@ -812,7 +812,7 @@ Se questo criterio non è configurato, i suggerimenti di ricerca saranno abilita
       <string id="SSLVersionMin">Abilita versione minima SSL</string>
       <string id="SSLVersionMin_Explain">Se questo criterio è abilitato, Firefox non utilizzerà versioni di SSL/TLS minori del valore specificato.
 
-Se questo criterio è disabilitato o non configurato, per impostazione predefinita Firefox utilizzerà TLS 1.0 come versione minima.</string>
+Se questo criterio è disabilitato o non configurato, per impostazione predefinita Firefox utilizzerà TLS 1.2 come versione minima.</string>
       <string id="SSLVersionMax">Abilita versione massima SSL</string>
       <string id="SSLVersionMax_Explain">Se questo criterio è abilitato, Firefox non utilizzerà versioni di SSL/TLS maggiori del valore specificato.
 

--- a/windows/ru-RU/firefox.adml
+++ b/windows/ru-RU/firefox.adml
@@ -812,7 +812,7 @@ If this policy is disabled or not configured, no PKCS #11 modules will be delete
       <string id="SSLVersionMin">Включить минимальную версию SSL</string>
       <string id="SSLVersionMin_Explain">Если эта политика включена, Firefox не будет использовать версии SSL/TLS меньше указанного значения.
 
-Если эта политика отключена или не настроена, Firefox по умолчанию использует как минимум TLS 1.0.</string>
+Если эта политика отключена или не настроена, Firefox по умолчанию использует как минимум TLS 1.2.</string>
        <string id="SSLVersionMax">Включить максимальную версию SSL</string>
        <string id="SSLVersionMax_Explain">Если эта политика включена, Firefox не будет использовать версии SSL/TLS, превышающие указанное значение.
 

--- a/windows/ru-RU/firefox.adml
+++ b/windows/ru-RU/firefox.adml
@@ -1269,9 +1269,12 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
          <checkBox refId="DNSOverHTTPSEnabled">Включить DNS через HTTPS.</checkBox>
          <checkBox refId="DNSOverHTTPSLocked">Запретить изенение настроек DNS через HTTPS.</checkBox>
        </presentation>
-       <presentation id="SSLVersion">
-         <dropdownList refId="SSLVersion" />
-       </presentation>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
+      </presentation>
        <presentation id="SupportMenu">
          <text>Заголовок:</text>
          <textBox refId="SupportMenuTitle">

--- a/windows/zh-CN/firefox.adml
+++ b/windows/zh-CN/firefox.adml
@@ -812,7 +812,7 @@ If this policy is disabled or not configured, no PKCS #11 modules will be delete
       <string id="SSLVersionMin">启用的最低 SSL 版本</string>
       <string id="SSLVersionMin_Explain">若启用此原则，Firefox 将不会使用低于指定版本的 SSL/TLS 版本进行连接。
 
-若禁用或不设定此原则，Firefox 的默认最低版本为 TLS 1.0。</string>
+若禁用或不设定此原则，Firefox 的默认最低版本为 TLS 1.2。</string>
       <string id="SSLVersionMax">启用的最高 SSL 版本</string>
       <string id="SSLVersionMax_Explain">若启用此原则，将不会使用高于指定版本的 SSL/TLS 版本进行连接。
 

--- a/windows/zh-CN/firefox.adml
+++ b/windows/zh-CN/firefox.adml
@@ -1269,8 +1269,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences。
         <checkBox refId="DNSOverHTTPSEnabled">启用DNS over httpS。</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">不允许变更 DNS over httpS 偏好设置。</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>标题：</text>

--- a/windows/zh-TW/firefox.adml
+++ b/windows/zh-TW/firefox.adml
@@ -810,7 +810,7 @@ If this policy is disabled or not configured, no PKCS #11 modules will be delete
       <string id="SSLVersionMin">啟用的最低 SSL 版本</string>
       <string id="SSLVersionMin_Explain">若啟用此原則，Firefox 將不會使用低於指定版本的 SSL/TLS 版本進行連線。
 
-若停用或不設定此原則，Firefox 的預設最低版本為 TLS 1.0。</string>
+若停用或不設定此原則，Firefox 的預設最低版本為 TLS 1.2。</string>
       <string id="SSLVersionMax">啟用的最高 SSL 版本</string>
       <string id="SSLVersionMax_Explain">若啟用此原則，將不會使用高於指定版本的 SSL/TLS 版本進行連線。
 

--- a/windows/zh-TW/firefox.adml
+++ b/windows/zh-TW/firefox.adml
@@ -1267,8 +1267,11 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences。
         <checkBox refId="DNSOverHTTPSEnabled">啟用 DNS over HTTPS。</checkBox>
         <checkBox refId="DNSOverHTTPSLocked">不允許變更 DNS over HTTPS 偏好設定。</checkBox>
       </presentation>
-      <presentation id="SSLVersion">
-        <dropdownList refId="SSLVersion"/>
+      <presentation id="SSLVersionMin">
+        <dropdownList refId="SSLVersion" defaultItem="2"/>
+      </presentation>
+      <presentation id="SSLVersionMax">
+        <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
         <text>標題：</text>


### PR DESCRIPTION
**Fixes #1039.** 

### This PR does the following:
- It updates the documentation and adds the default value for both policies to it.
- It fixes the explanation of `SSLVersionMin` policy by changing the default value to `TLS1.2` in the ADMX templates for Windows.
- It adds `defaultValue` property to the presentation definition in the ADMX templates for Windows. (Now when the policy is set to enabled the default value of FF is selected automatically.)
