### PR TITLE
Fix wrong html entity

### DIFF
--- a/mac/org.mozilla.firefox.plist
+++ b/mac/org.mozilla.firefox.plist
@@ -601,7 +601,7 @@
 		<key>SocksVersion</key>
 		<string>4</string>
 		<key>Passthrough</key>
-		<string>&lt;local&rt;</string>
+		<string>&lt;local&gt;</string>
 		<key>AutoConfigURL</key>
 		<string>URL_TO_AUTOCONFIG</string>
 		<key>AutoLogin</key>


### PR DESCRIPTION
Found this, because the plist parser complained about an unknown entity.