### PR TITLE
Fix `InstallAddonsPermission` Preferences Affected Discrepancy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3547,7 +3547,7 @@ Configure the default extension install policy as well as origins for extension 
 
 **Compatibility:** Firefox 60, Firefox ESR 60\
 **CCK2 Equivalent:** `permissions.install`\
-**Preferences Affected:** `xpinstall.enabled`
+**Preferences Affected:** `xpinstall.enabled`, `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons`, `browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features`
 
 #### Windows (GPO)
 ```


### PR DESCRIPTION
This should be done also in #1098, sorry for missing this one.

https://searchfox.org/mozilla-central/rev/b41bb321fe4bd7d03926083698ac498ebec0accf/browser/components/enterprisepolicies/Policies.sys.mjs#1543-1564

```js
  InstallAddonsPermission: {
    onBeforeUIStartup(manager, param) {
      if ("Allow" in param) {
        addAllowDenyPermissions("install", param.Allow, null);
      }
      if ("Default" in param) {
        setAndLockPref("xpinstall.enabled", param.Default);
        if (!param.Default) {
          blockAboutPage(manager, "about:debugging");
          setAndLockPref(
            "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons",
            false
          );
          setAndLockPref(
            "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features",
            false
          );
          manager.disallowFeature("xpinstall");
        }
      }
    },
  },
```