### PR TITLE
Add documentation for Mixed Content Level 2 and GPC prefs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4719,6 +4719,7 @@ pdfjs. (Firefox 84, Firefox ESR 78.6)
 places.
 pref.
 print.
+privacy.globalprivacycontrol.enabled (Firefox 127, Firefox ESR 128.0)
 privacy.userContext.enabled (Firefox 126, Firefox ESR 115.11)
 privacy.userContext.ui.enabled (Firefox 126, Firefox ESR 115.11)
 signon. (Firefox 83, Firefox ESR 78.5)
@@ -4744,7 +4745,11 @@ as well as the following security preferences:
 | security.insecure_connection_text.pbmode.enabled | bool | false
 | &nbsp;&nbsp;&nbsp;&nbsp;If set to true, adds the words "Not Secure" for insecure sites in private browsing.
 | security.mixed_content.block_active_content | boolean | true
-| &nbsp;&nbsp;&nbsp;&nbsp;If false, mixed active content (HTTP and HTTPS) is not blocked.
+| &nbsp;&nbsp;&nbsp;&nbsp;If set to true, mixed active content (HTTP subresources such as scripts, fetch requests, etc. on a HTTPS page) will be blocked.
+| security.mixed_content.block_display_content | boolean | false
+| &nbsp;&nbsp;&nbsp;&nbsp;If set to true, mixed passive/display content (HTTP subresources such as images, videos, etc. on a HTTPS page) will be blocked. (Firefox 127, Firefox ESR 128.0)
+| security.mixed_content.upgrade_display_content | boolean | true
+| &nbsp;&nbsp;&nbsp;&nbsp;If set to true, mixed passive/display content (HTTP subresources such as images, videos, etc. on a HTTPS page) will be upgraded to HTTPS. (Firefox 127, Firefox ESR 128.0)
 | security.osclientcerts.autoload | boolean | false
 | &nbsp;&nbsp;&nbsp;&nbsp;If true, client certificates are loaded from the operating system certificate store.
 | security.OCSP.enabled | integer | 1

--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -3359,6 +3359,26 @@
         <decimal value="0"/>
       </disabledValue>
     </policy>
+    <policy name="security_mixed_content_block_display_content" class="Both" displayName="$(string.security_mixed_content_block_display_content)" explainText="$(string.Preferences_Boolean_Explain)" key="Software\Policies\Mozilla\Firefox\Preferences" valueName="security.mixed_content.block_display_content">
+      <parentCategory ref="Preferences"/>
+      <supportedOn ref="SUPPORTED_FF127"/>
+      <enabledValue>
+        <decimal value="0"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="1"/>
+      </disabledValue>
+    </policy>
+    <policy name="security_mixed_content_upgrade_display_content" class="Both" displayName="$(string.security_mixed_content_upgrade_display_content)" explainText="$(string.Preferences_Boolean_Explain)" key="Software\Policies\Mozilla\Firefox\Preferences" valueName="security.mixed_content.upgrade_display_content">
+      <parentCategory ref="Preferences"/>
+      <supportedOn ref="SUPPORTED_FF127"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
     <policy name="security_ssl_errorReporting_enabled" class="Both" displayName="$(string.security_ssl_errorReporting_enabled)" explainText="$(string.Preferences_Boolean_Explain)" key="Software\Policies\Mozilla\Firefox\Preferences" valueName="security.ssl.errorReporting.enabled">
       <parentCategory ref="Preferences"/>
       <supportedOn ref="SUPPORTED_FF68"/>


### PR DESCRIPTION
Addressing the changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1882559