### PR TITLE
Update SOCKS proxyDNS policy documents for Firefox 128+

### DIFF
--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -1045,10 +1045,13 @@ Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, umgeh
       <string id="Proxy_AutoLogin_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, wird Firefox nicht zur Proxy-Authentifizierung auffordern, wenn ein Kennwort gespeichert wird.
 
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, wird Firefox immer zur Proxy-Authentifizierung auffordern.</string>
-      <string id="Proxy_UseProxyForDNS">Proxy DNS bei Verwendung von SOCKS v5</string>
-      <string id="Proxy_UseProxyForDNS_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, wird DNS bei Verwendung von SOCKS v5 als Proxy verwendet.
+      <string id="Proxy_UseProxyForDNS">Proxy DNS bei Verwendung von SOCKS</string>
+      <string id="Proxy_UseProxyForDNS_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, wird bei Verwendung eines SOCKS-Proxies die DNS-Anfragen vom Proxy-Server aufgelöst.
 
-Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, wird DNS bei der Verwendung von SOCKS v5 nicht über einen Proxy geleitet.</string>
+Wenn diese Richtlinieneinstellung deaktiviert ist, wird DNS bei der Verwendung von SOCKS nicht über einen Proxy geleitet.
+
+Wenn diese Richtlinieneinstellung nicht konfiguriert ist, wird DNS bei der Verwendung von SOCKS v4 nicht über einen Proxy geleitet, bei SOCKS v5 wird die DNS-Anfrage vom Proxy-Server aufgelöst</string>
+
       <string id="DisableThirdPartyModuleBlocking">Blockierung von Drittanbietermodulen deaktivieren</string>
       <string id="DisableThirdPartyModuleBlocking_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, dürfen Benutzer keine Module von Drittanbietern auf der Seite about:third-party blockieren.
 

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -1040,10 +1040,12 @@ If this policy is disabled or not configured, Firefox does not bypass the proxy.
       <string id="Proxy_AutoLogin_Explain">If this policy is enabled, Firefox will not prompt for proxy authentication when a password is saved.
 
 If this policy is disabled or not configured, Firefox will always prompt for proxy authentication.</string>
-      <string id="Proxy_UseProxyForDNS">Proxy DNS when using SOCKS v5</string>
-      <string id="Proxy_UseProxyForDNS_Explain">If this policy is enabled, DNS is proxied when using SOCKS v5.
+      <string id="Proxy_UseProxyForDNS">Proxy DNS when using SOCKS</string>
+      <string id="Proxy_UseProxyForDNS_Explain">If this policy is enabled, DNS is proxied when using SOCKS.
 
-If this policy is disabled or not configured, DNS is not proxied when using SOCKS v5.</string>
+If this policy is disabled, DNS is not proxied when using SOCKS.
+
+If this policy not configured, DNS is not proxied when using SOCKS v4, but proxied when using SOCKS v5.</string>
       <string id="DisableThirdPartyModuleBlocking">Disable Third Party Module Blocking</string>
       <string id="DisableThirdPartyModuleBlocking_Explain">If this policy is enabled, users are not allowed to block third-party modules from the about:third-party page.
 


### PR DESCRIPTION
Changed in [Bug 1741375](https://bugzilla.mozilla.org/1741375). Noticed stale document in [Bug 1924654](https://bugzilla.mozilla.org/1924654).

Note that the documentation was slightly incorrect before, the config already affected both SOCKS v4 and SOCKS v5.

Not sure if we also want to document the behavior up to 127 like in https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy/settings#proxydns