### PR TITLE
Fix formatting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1385,7 +1385,6 @@ Value (string):
 ```
 <enabled/> or <disabled/>
 ```
-```
 OMA-URI:
 ```
 ./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox~ContentAnalysis/ContentAnalysis_InterceptionPoints_DragAndDrop_Enabled
@@ -1394,7 +1393,6 @@ Value (string):
 ```
 <enabled/> or <disabled/>
 ```
-```
 OMA-URI:
 ```
 ./Device/Vendor/MSFT/Policy/Config/Firefox~Policy~firefox~ContentAnalysis/ContentAnalysis_InterceptionPoints_FileUpload_Enabled
@@ -1402,7 +1400,6 @@ OMA-URI:
 Value (string):
 ```
 <enabled/> or <disabled/>
-```
 ```
 OMA-URI:
 ```


### PR DESCRIPTION
Recent changes in https://github.com/mozilla/policy-templates/pull/1173 completely broke formatting for policies under `ContentAnalysis`. 

Ex:

![111](https://github.com/user-attachments/assets/a4ace9db-ff7b-4963-9cb0-2ab226de6ab4)

![1111](https://github.com/user-attachments/assets/1431a17e-e775-438a-978c-c414cb23a9cb)


This fixes it.