### PR TITLE
feat: Add more warns about policy docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,7 +1,7 @@
 <!--
-⚠️ WARNING: This repository is being migrated to
+⚠️ WARNING: Documentation for policy behavior and syntax is being migrated to
 https://github.com/mozilla/enterprise-admin-reference.
-Please open pull requests for new policy documentation there instead.
+Please open pull requests for new Enterprise Policies there instead.
 -->
 
 **Description:**

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,19 @@
+<!--
+⚠️ WARNING: This repository is being migrated to
+https://github.com/mozilla/enterprise-admin-reference.
+Please open pull requests for new policy documentation there instead.
+-->
+
+**Description:**
+
+<!-- ✍️ Summarize your changes in one or two sentences. -->
+
+**Motivation:**
+
+<!-- ❓ Why are you making these changes and how do they help? -->
+
+**Related issues and pull requests:**
+
+<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
+<!-- 👉 Highlight related pull requests using "Relates to #123" -->
+<!-- ❗ If another pull request must be merged first, use "**Depends on:** #123" -->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,7 +1,7 @@
 <!--
 ⚠️ WARNING: Documentation for policy behavior and syntax is being migrated to
 https://github.com/mozilla/enterprise-admin-reference.
-Please open pull requests for new Enterprise Policies there instead.
+Pull requests adding documentation for new policies should be opened there instead.
 -->
 
 **Description:**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Policies are commonly used in enterprise or managed environments such as busines
 
 ## Policy documentation
 
-Documentation for policy behavior and syntax is moving to [Firefox Admin Docs](https://firefox-admin-docs.mozilla.org/reference/policies/).
+> [!WARNING]
+> Documentation for policy behavior and syntax is moving to [Firefox Admin Docs](https://firefox-admin-docs.mozilla.org/reference/policies/).
+
 The new docs repository is public and open to contributions, so if you want to make improvements, feel free to contribute at https://github.com/mozilla/enterprise-admin-reference.
 See the [GitHub Discussion](https://github.com/mozilla/policy-templates/discussions/1291) for more information.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> Policy documentation is being migrated to the [Firefox administrator reference](https://firefox-admin-docs.mozilla.org/).
+> This page may not be updated as of May 2026.
+
 Firefox policies can be specified using the [Group Policy templates on Windows](https://github.com/mozilla/policy-templates/tree/master/windows), [Intune on Windows](https://support.mozilla.org/kb/managing-firefox-intune), [configuration profiles on macOS](https://github.com/mozilla/policy-templates/tree/master/mac), or by creating a file called `policies.json`. On Windows, create a directory called `distribution` where the EXE is located and place the file there. On Mac, the file goes into `Firefox.app/Contents/Resources/distribution`.  On Linux, the file goes into `firefox/distribution`, where `firefox` is the installation directory for firefox, which varies by distribution or you can specify system-wide policy by placing the file in `/etc/firefox/policies`.
 
 Unfortunately, JSON files do not support comments, but you can add extra entries to the JSON to use as comments. You will see an error in about:policies, but the policies will still work properly. For example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 > [!WARNING]
-> Policy documentation is being migrated to the [Firefox administrator reference](https://firefox-admin-docs.mozilla.org/).
-> This page may not be updated as of May 2026.
+> Documentation for policy behavior and syntax is being migrated to the [Firefox administrator reference](https://firefox-admin-docs.mozilla.org/).
 
 Firefox policies can be specified using the [Group Policy templates on Windows](https://github.com/mozilla/policy-templates/tree/master/windows), [Intune on Windows](https://support.mozilla.org/kb/managing-firefox-intune), [configuration profiles on macOS](https://github.com/mozilla/policy-templates/tree/master/mac), or by creating a file called `policies.json`. On Windows, create a directory called `distribution` where the EXE is located and place the file there. On Mac, the file goes into `Firefox.app/Contents/Resources/distribution`.  On Linux, the file goes into `firefox/distribution`, where `firefox` is the installation directory for firefox, which varies by distribution or you can specify system-wide policy by placing the file in `/etc/firefox/policies`.
 


### PR DESCRIPTION
As we're migrating policy docs across, adding a few extra warns here.

Rationale is we're still getting PRs for new policies and we should be directing to https://github.com/mozilla/enterprise-admin-reference