### PR TITLE
Improved ru-lang policies presentation

### DIFF
--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -1572,9 +1572,8 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
         </textBox>
       </presentation>
       <presentation id="HomepageURL">
-        <text>URL:</text>
         <textBox refId="HomepageURL">
-          <label/>
+          <label>URL:</label>
         </textBox>
         <checkBox refId="HomepageLocked">Don't allow the homepage to be changed.</checkBox>
       </presentation>
@@ -1585,23 +1584,18 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
         <dropdownList refId="StartPage"/>
       </presentation>
       <presentation id="Bookmark">
-        <text>Title:</text>
         <textBox refId="BookmarkTitle">
-          <label/>
+          <label>Title:</label>
         </textBox>
-        <text>URL:</text>
         <textBox refId="BookmarkURL">
-          <label/>
+          <label>URL:</label>
         </textBox>
-        <text>Favicon URL:</text>
         <textBox refId="BookmarkFavicon">
-          <label/>
+          <label>Favicon URL:</label>
         </textBox>
-        <text>Placement:</text>
-        <dropdownList refId="BookmarkPlacement"/>
-        <text>Folder name:</text>
+        <dropdownList refId="BookmarkPlacement">Placement:</dropdownList>
         <textBox refId="BookmarkFolder">
-          <label/>
+          <label>Folder name:</label>
         </textBox>
       </presentation>
       <presentation id="SearchEngine">
@@ -1647,17 +1641,14 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
         <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
       <presentation id="SupportMenu">
-        <text>Title:</text>
         <textBox refId="SupportMenuTitle">
-          <label/>
+          <label>Title:</label>
         </textBox>
-        <text>URL:</text>
         <textBox refId="SupportMenuURL">
-          <label/>
+          <label>URL:</label>
         </textBox>
-        <text>Access key:</text>
         <textBox refId="SupportMenuAccessKey">
-          <label/>
+          <label>Access key:</label>
         </textBox>
       </presentation>
       <presentation id="Preferences_String">
@@ -1732,9 +1723,8 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
         </textBox>
       </presentation>
       <presentation id="Proxy_SOCKSProxy">
-        <text>Host including port:</text>
         <textBox refId="Proxy_SOCKSProxy">
-          <label/>
+          <label>Host including port:</label>
         </textBox>
         <text>SOCKS Version:</text>
         <dropdownList refId="Proxy_SOCKSVersion"/>
@@ -1745,9 +1735,8 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</
         </textBox>
       </presentation>
       <presentation id="Proxy_Passthrough">
-        <text>No proxy for</text>
         <textBox refId="Proxy_Passthrough">
-          <label/>
+          <label>No proxy for</label>
         </textBox>
         <text>Example: .mozilla.org, .net.nz, 192.168.1.0/24</text>
         <text>Connections to localhost, 127.0.0.1/8, and ::1 are never proxied.</text>

--- a/windows/ru-RU/firefox.adml
+++ b/windows/ru-RU/firefox.adml
@@ -1574,9 +1574,8 @@ https://mozilla.github.io/policy-templates/#preferences.</string>
         </textBox>
       </presentation>
       <presentation id="HomepageURL">
-        <text>URL:</text>
         <textBox refId="HomepageURL">
-          <label/>
+          <label>URL:</label>
         </textBox>
         <checkBox refId="HomepageLocked">Не позволять изменять домашнюю страницу.</checkBox>
        </presentation>
@@ -1587,23 +1586,18 @@ https://mozilla.github.io/policy-templates/#preferences.</string>
         <dropdownList refId="StartPage"/>
       </presentation>
       <presentation id="Bookmark">
-        <text>Заголовок:</text>
         <textBox refId="BookmarkTitle">
-          <label/>
+          <label>Заголовок:</label>
         </textBox>
-        <text>URL:</text>
         <textBox refId="BookmarkURL">
-          <label/>
+          <label>URL:</label>
         </textBox>
-        <text>URL-адрес значка:</text>
         <textBox refId="BookmarkFavicon">
-          <label/>
+          <label>URL-адрес значка:</label>
         </textBox>
-        <text>Размещение:</text>
-        <dropdownList refId="BookmarkPlacement"/>
-        <text>Имя папки:</text>
+        <dropdownList refId="BookmarkPlacement">Размещение:</dropdownList>
         <textBox refId="BookmarkFolder">
-          <label/>
+          <label>Имя папки:</label>
         </textBox>
       </presentation>
       <presentation id="SearchEngine">
@@ -1649,17 +1643,14 @@ https://mozilla.github.io/policy-templates/#preferences.</string>
         <dropdownList refId="SSLVersion" defaultItem="3"/>
       </presentation>
        <presentation id="SupportMenu">
-         <text>Заголовок:</text>
          <textBox refId="SupportMenuTitle">
-           <label/>
+           <label>Заголовок:</label>
          </textBox>
-         <text>URL:</text>
          <textBox refId="SupportMenuURL">
-           <label/>
+           <label>URL:</label>
          </textBox>
-         <text>Ключ доступа:</text>
         <textBox refId="SupportMenuAccessKey">
-          <label/>
+          <label>Ключ доступа:</label>
         </textBox>
       </presentation>
       <presentation id="Preferences_String">
@@ -1734,9 +1725,8 @@ https://mozilla.github.io/policy-templates/#preferences.</string>
         </textBox>
       </presentation>
       <presentation id="Proxy_SOCKSProxy">
-        <text>SOCKS хост:</text>
         <textBox refId="Proxy_SOCKSProxy">
-          <label/>
+          <label>SOCKS хост:</label>
         </textBox>
         <text>Версия SOCKS:</text>
         <dropdownList refId="Proxy_SOCKSVersion"/>
@@ -1747,9 +1737,8 @@ https://mozilla.github.io/policy-templates/#preferences.</string>
         </textBox>
       </presentation>
       <presentation id="Proxy_Passthrough">
-        <text>Нет прокси для</text>
         <textBox refId="Proxy_Passthrough">
-          <label/>
+          <label>Нет прокси для</label>
         </textBox>
         <text>Пример: .mozilla.org, .net.nz, 192.168.1.0/24</text>
         <text>Подключения к localhost, 127.0.0.1/8 и ::1 никогда не проксируются.</text>


### PR DESCRIPTION
Hello, dear Mozilla developers. We actively use your Group Policy templates for Firefox. Recently, we encountered the following issue in our Group Policy Editor - GPUI. In the presentation field, the text and fields were misaligned. To resolve this issue, I slightly modified the tags in the presentation field in the Russian-language ADMX templates, preserving the structure, thereby achieving correct display. Accepting this change will not affect the display in the Windows Policy Editor.

https://bugzilla.altlinux.org/49053 - link describing the bug.

If these changes are accepted and approved, I will prepare a PR to improve presentations for other languages.

Sincerely, Valentin Sokolov.

<img width="1371" height="996" alt="screen" src="https://github.com/user-attachments/assets/5ddd4ede-b765-4e44-b074-9d8eed12de04" />
<img width="1024" height="768" alt="firefox-homepage-url" src="https://github.com/user-attachments/assets/354b18e0-fadb-4626-a721-af374b227742" />

<img width="814" height="295" alt="ImprovedPresentation" src="https://github.com/user-attachments/assets/84d5a507-83a0-4808-8f75-99c523333ea6" />