### PR TITLE
Add SitePolicies policy

### DIFF
--- a/linux/policies.json
+++ b/linux/policies.json
@@ -417,6 +417,21 @@
       "NAME_OF_DEVICE": "PATH_TO_LIBRARY_FOR_DEVICE"
     },
     "ShowHomeButton": true | false,
+    "SitePolicies": [
+      {
+        "Match": ["*.example.com"],
+        "Policies": {
+          "DisableJit": true | false,
+          "HttpsOnly": true | false
+        }
+      },
+      {
+        "Exceptions": ["*.example.org"],
+        "Policies": {
+          "DisableJit": true | false
+        }
+      }
+    ],
     "SkipTermsOfUse": true | false,
     "SSLVersionMax": "tls1" | "tls1.1" | "tls1.2" | "tls1.3",
     "SSLVersionMin": "tls1" | "tls1.1" | "tls1.2" | "tls1.3",

--- a/mac/org.mozilla.firefox.plist
+++ b/mac/org.mozilla.firefox.plist
@@ -779,6 +779,33 @@
 	</dict>
 	<key>ShowHomeButton</key>
 	<true/>
+	<key>SitePolicies</key>
+	<array>
+		<dict>
+			<key>Match</key>
+			<array>
+				<string>*.example.com</string>
+			</array>
+			<key>Policies</key>
+			<dict>
+				<key>DisableJit</key>
+				<true/>
+				<key>HttpsOnly</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+			<key>Exceptions</key>
+			<array>
+				<string>*.example.org</string>
+			</array>
+			<key>Policies</key>
+			<dict>
+				<key>DisableJit</key>
+				<true/>
+			</dict>
+		</dict>
+	</array>
 	<key>SkipTermsOfUse</key>
 	<true/>
 	<key>SSLVersionMin</key>

--- a/scripts/generate_oma_uris.py
+++ b/scripts/generate_oma_uris.py
@@ -52,6 +52,8 @@ JSON_POLICIES = {
     "ManagedBookmarksOneLine",
     "Preferences",
     "PreferencesOneLine",
+    "SitePolicies",
+    "SitePoliciesOneLine",
     "WebsiteFilter",
     "WebsiteFilterOneLine",
 }

--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -1467,6 +1467,13 @@ Hinweis: Wenn andere Richtlinieneinstellungen konfiguriert sind und diese Einste
 Wenn diese Richtlinieneinstellung deaktiviert ist, wird XSLT (Extensible Stylesheet Language Transformations) deaktiviert.
 
 Wenn diese Richtlinieneinstellung nicht konfiguriert ist, gilt die Firefox-Standardeinstellung.</string>
+      <string id="SitePolicies">Webseiten-Richtlinien (JSON)</string>
+      <string id="SitePoliciesOneLine">Webseiten-Richtlinien (Einzeiliger JSON-Code)</string>
+      <string id="SitePolicies_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, können Sie über JSON website-spezifische Richtlinien-Überschreibungen angeben.
+
+Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden keine website-spezifischen Richtlinien angewendet.
+
+Für detaillierte Informationen bitte die Dokumentation (in englischer Sprache) lesen: https://firefox-admin-docs.mozilla.org/reference/policies/sitepolicies/.</string>
       <string id="LocalNetworkAccess_Enabled">Aktiviert</string>
       <string id="LocalNetworkAccess_Enabled_Explain">Wenn diese Richtlinieneinstellung aktiviert oder nicht konfiguriert ist, werden Sicherheitsprüfungen für den lokalen Netzwerkzugriff erzwungen.
 

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -1461,6 +1461,13 @@ Note: If any other policies are configured and this policy is not set, the Web S
 If this policy is disabled, XSLT (Extensible Stylesheet Language Transformations) is disabled.
 
 If this policy is not configured, the Firefox default applies.</string>
+      <string id="SitePolicies">Site Policies (JSON)</string>
+      <string id="SitePoliciesOneLine">Site Policies (JSON on one line)</string>
+      <string id="SitePolicies_Explain">If this policy is enabled, you can specify per-site policy overrides via JSON.
+
+If this policy is disabled or not configured, no site-specific policies are applied.
+
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/sitepolicies/.</string>
       <string id="LocalNetworkAccess_Enabled">Enabled</string>
       <string id="LocalNetworkAccess_Enabled_Explain">If this policy is enabled or not configured, local network access security checks are enforced.
 

--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -5200,5 +5200,19 @@
         <decimal value="0"/>
       </disabledValue>
     </policy>
+    <policy name="SitePolicies" class="Both" displayName="$(string.SitePolicies)" explainText="$(string.SitePolicies_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.JSON)">
+      <parentCategory ref="firefox"/>
+      <supportedOn ref="SUPPORTED_FF150_ONLY"/>
+      <elements>
+        <multiText id="JSON" valueName="SitePolicies" maxLength="16384"/>
+      </elements>
+    </policy>
+    <policy name="SitePoliciesOneLine" class="Both" displayName="$(string.SitePoliciesOneLine)" explainText="$(string.SitePolicies_Explain)" key="Software\Policies\Mozilla\Firefox" presentation="$(presentation.JSONOneLine)">
+      <parentCategory ref="firefox"/>
+      <supportedOn ref="SUPPORTED_FF150_ONLY"/>
+      <elements>
+        <text id="JSONOneLine" valueName="SitePolicies" maxLength="16384"/>
+      </elements>
+    </policy>
   </policies>
 </policyDefinitions>

--- a/windows/fr-FR/firefox.adml
+++ b/windows/fr-FR/firefox.adml
@@ -1468,6 +1468,13 @@ Remarque : si d’autres stratégies sont configurées et que celle-ci ne l’es
 Si cette stratégie est désactivée, XSLT (Extensible Stylesheet Language Transformations) est désactivé.
 
 Si cette stratégie n’est pas configurée, le paramètre par défaut de Firefox s’applique.</string>
+      <string id="SitePolicies">Stratégies de sites web (JSON)</string>
+      <string id="SitePoliciesOneLine">Stratégies de sites web (JSON sur une seule ligne)</string>
+      <string id="SitePolicies_Explain">Si cette stratégie est activée, vous pouvez spécifier via JSON des surcharges de stratégie propres à certains sites.
+
+Si cette stratégie est désactivée ou non configurée, aucune stratégie propre à un site n’est appliquée.
+
+Pour plus d'informations sur la création de la stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/sitepolicies/.</string>
       <string id="LocalNetworkAccess_Enabled">Activé</string>
       <string id="LocalNetworkAccess_Enabled_Explain">Si cette stratégie est activée ou non configurée, les contrôles de sécurité pour l’accès au réseau local sont appliqués.
 

--- a/windows/ru-RU/firefox.adml
+++ b/windows/ru-RU/firefox.adml
@@ -1463,6 +1463,13 @@ Mozilla рекомендует не отключать телеметрию. И�
 Если эта политика отключена, XSLT (Extensible Stylesheet Language Transformations) отключён.
 
 Если эта политика не настроена, применяется настройка Firefox по умолчанию.</string>
+      <string id="SitePolicies">Политики веб-сайтов (JSON)</string>
+      <string id="SitePoliciesOneLine">Политики веб-сайтов (JSON в одной строке)</string>
+      <string id="SitePolicies_Explain">Если эта политика включена, вы можете с помощью JSON задать переопределения политик для отдельных сайтов.
+
+Если эта политика отключена или не настроена, политики для отдельных сайтов не применяются.
+
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/sitepolicies/.</string>
       <string id="LocalNetworkAccess_Enabled">Включено</string>
       <string id="LocalNetworkAccess_Enabled_Explain">Если эта политика включена или не настроена, проверки безопасности доступа к локальной сети применяются.
 


### PR DESCRIPTION
Adds the `SitePolicies` policy, which was previously the only enterprise-supported schema
policy with no ADMX coverage at all.

`SitePolicies` is an array of objects (each with a `Match` or `Exceptions` site-pattern
list plus a `Policies` object), so it gets the JSON-blob treatment rather than a category
of sub-policies — there's no sensible ADMX shape for an array of objects. Both the
multi-line `SitePolicies` form and the `SitePoliciesOneLine` variant are included, the
latter to work around Intune's per-string length limit.

The explain text stays short and points at
https://firefox-admin-docs.mozilla.org/reference/policies/sitepolicies/ for the details
(rule ordering, the registerable-domain restriction on site patterns, and the `DisableJit`
performance caveat), following the same pattern the other JSON-blob policies use.

### Version label

Uses `SUPPORTED_FF150_ONLY`, which matches the published docs: Firefox 150, Firefox
Enterprise 150, ESR 153. Because ESR 153 postdates the release version, this isn't an ESR
backport, so it takes the `_ONLY` label — same as `XSLTEnabled` (151 / ESR 153). No new
`supportedOn` definition is needed; `SUPPORTED_FF150_ONLY` already exists in the ADMX and
all four ADMLs.

### Files touched

- `windows/firefox.admx` — the two `<policy>` elements
- `windows/en-US`, `de-DE`, `fr-FR`, `ru-RU` `firefox.adml` — display names, explain text
- `linux/policies.json`, `mac/org.mozilla.firefox.plist` — samples covering both the
  `Match` and `Exceptions` forms, and both `DisableJit` and `HttpsOnly`
- `scripts/generate_oma_uris.py` — registers both names in `JSON_POLICIES` so they render
  as JSON blob entries instead of enable/disable toggles

### Verification

- All five XML files parse.
- Every `$(string.*)` and `$(presentation.*)` reference in the ADMX resolves in all four
  ADMLs (no orphans).
- `scripts/generate_oma_uris.py` runs clean and emits a `## SitePolicies` anchor for
  cross-linking from firefox-admin-docs.
- `multiText` produces `REG_MULTI_SZ`, matching the registry type in the published docs.

### Known limitation (pre-existing, not fixed here)

The OMA-URI doc shows the generic `... JSON - see policy docs for schema ...` placeholder
for `SitePolicies` rather than embedding the `linux/policies.json` sample. This is a
pre-existing bug in `load_json_samples()`: its flat text scan desyncs inside
`SanitizeOnShutdown`'s nested object and stops early, so every policy alphabetically after
it is missing from the sample map — `SearchEngines`, `SupportMenu`, and `WebsiteFilter`
are all affected on `master` today. Worth a separate fix.
