### PR TITLE
Point ADML doc links at firefox-admin-docs.mozilla.org

### DIFF
--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -386,7 +386,7 @@ Wenn Sie die Richtlinieneinstellung aktivieren oder nicht konfigurieren, werden 
 
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden Erweiterungen nicht mit einer Richtlinie verwaltet.
 
-Für detaillierte Informationen bitte die Dokumentation (in englischer Sprache) lesen: https://github.com/mozilla/policy-templates/blob/master/README.md#extensionsettings.</string>
+Für detaillierte Informationen bitte die Dokumentation (in englischer Sprache) lesen: https://firefox-admin-docs.mozilla.org/reference/policies/extensionsettings/.</string>
       <string id="HardwareAcceleration">Hardware-Beschleunigung</string>
       <string id="HardwareAcceleration_Explain">Wenn Sie die Richtlinieneinstellung deaktivieren, wird die Hardware-Beschleunigung deaktiviert.
 
@@ -1010,7 +1010,7 @@ Wenn diese Richtlinieneinstellung nicht konfiguriert ist, können Nutzer ein Mas
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden die Standardeinstellungen verwendet und können vom Nutzer modifiziert werden.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#handlers (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/handlers/ (Englisch)</string>
       <string id="PreferencesOneLine">Einstellungen (Einzeiliger JSON-Code)</string>
       <string id="Preferences">Einstellungen</string>
       <string id="Preferences_Explain">Hinweis: Um diese Richtlinieneinstellungen nutzen zu können, müssen Sie zunächst alle Einstellungen im Abschnitt Einstellungen (Veraltet) löschen.
@@ -1020,7 +1020,7 @@ Wenn diese Richtlinieneinstellung aktiviert ist, können Sie Einstellungen mit H
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden die Einstellungen nicht verändert.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/ (Englisch)</string>
       <string id="BookmarksOneLine">Lesezeichen (Einzeiliger JSON-Code)</string>
       <string id="Bookmarks">Lesezeichen (JSON)</string>
       <string id="Bookmarks_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, können Sie Lesezeichen mit JSON konfigurieren. Mit [] können Sie alle Lesezeichen löschen.
@@ -1032,7 +1032,7 @@ Wenn diese Richtlinieneinstellung zusammen mit der für die individuellen Leseze
 Diese Richtlinieneinstellung wirkt sich nicht auf verwaltete Lesezeichen aus.
 
 Für Informationen über die JSON-Struktur, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#bookmarks (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/bookmarks/ (Englisch)</string>
       <string id="ManagedBookmarksOneLine">Verwaltete Lesezeichen (Einzeiliger JSON-Code)</string>
       <string id="ManagedBookmarks">Verwaltete Lesezeichen</string>
       <string id="ManagedBookmarks_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, können Sie verwaltete Lesezeichen mit Hilfe einer JSON-Datei konfigurieren.
@@ -1040,7 +1040,7 @@ https://github.com/mozilla/policy-templates/blob/master/README.md#bookmarks (Eng
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden keine verwalteten Lesezeichen hinzugefügt.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#managedbookmarks (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/managedbookmarks/ (Englisch)</string>
       <string id="AllowedDomainsForApps">Domains, die auf Google Workspace zugreifen dürfen</string>
       <string id="AllowedDomainsForApps_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, können Anwender nur für definierte Domains auf Google Workspace zugreifen. Domains werden durch Kommas getrennt. Um den Zugriff auf Gmail zu erlauben, fügen Sie consumer_accounts hinzu.
 
@@ -1056,7 +1056,7 @@ Wenn diese Richtlinieneinstellung aktiviert oder nicht konfiguriert ist, können
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, wird jede Seite, die ein externes Protokoll ausführt, den Benutzer um Erlaubnis fragen.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#autolaunchprotocolsfromorigins (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/autolaunchprotocolsfromorigins/ (Englisch)</string>
       <string id="WindowsSSO">Windows SSO</string>
       <string id="WindowsSSO_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, verwendet Firefox in Windows gespeicherte Zugangsdaten, um Sie auf Webseiten von Microsoft anzumelden, einschließlich Outlook, Office 365 sowie allen anderen Geschäfts- oder Schulkonten, die Microsofts Authentifizierung verwenden.
 
@@ -1071,7 +1071,7 @@ Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, zeigt
 
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden Warnungen für alle ausführbaren Dateitypen angezeigt.
 
-Ausführliche Informationen zur Erstellung der Richtlinie finden Sie unter https://github.com/mozilla/policy-templates/blob/master/README.md#exemptdomainfiletypepairsfromfiletypedownloadwarnings.</string>
+Ausführliche Informationen zur Erstellung der Richtlinie finden Sie unter https://firefox-admin-docs.mozilla.org/reference/policies/exemptdomainfiletypepairsfromfiletypedownloadwarnings/.</string>
       <string id="StartDownloadsInTempDirectory">Downloads im temporären Verzeichnis starten</string>
       <string id="StartDownloadsInTempDirectory_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, startet Firefox Downloads in einem temporären Verzeichnis und löscht sie automatisch, wenn der Browser geschlossen wird.
 
@@ -1137,7 +1137,7 @@ Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, dürf
 
 Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, werden die integrierten Standardwerte verwendet.
 
-Ausführliche Informationen zur Erstellung der Richtlinie finden Sie unter https://github.com/mozilla/policy-templates/blob/master/README.md#containers.</string>
+Ausführliche Informationen zur Erstellung der Richtlinie finden Sie unter https://firefox-admin-docs.mozilla.org/reference/policies/containers/.</string>
       <string id="FirefoxSuggest_WebSuggestions">Vorschläge aus dem Internet</string>
       <string id="FirefoxSuggest_WebSuggestions_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, erhalten Sie von Firefox Vorschläge, die mit Ihrer Suche zusammenhängen.
 
@@ -1488,15 +1488,15 @@ Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, kann 
       <string id="Preferences_Boolean_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, ist die Einstellung auf true gesperrt. Wenn diese Richtlinieneinstellung deaktiviert ist, ist die Einstellung auf false gesperrt.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/ (Englisch)</string>
       <string id="Preferences_String_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, ist die Einstellung auf den spezifizierten String-Wert gesperrt. Wenn diese Richtlinieneinstellung deaktiviert ist, hat sie keinen Effekt.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/ (Englisch)</string>
       <string id="Preferences_Enum_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, ist sie auf den spezifizierten Wert gesperrt. Wenn diese Richtlinieneinstellung deaktiviert ist, hat sie keinen Effekt.
 
 Für eine Beschreibung der Einstellung, siehe:
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences (Englisch)</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/ (Englisch)</string>
       <string id="Preferences_Unsupported_Explain">Diese Richtlinieneinstellung ist nicht mehr unterstützt. Wir arbeiten an einer Lösung.</string>
       <string id="Preferences_accessibility_force_disabled_auto">Automatisch (0)</string>
       <string id="Preferences_accessibility_force_disabled_off">Immer Aus (1)</string>

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -385,7 +385,7 @@ If this policy is enabled or not configured, extensions will be updated automati
 
 If this policy is disabled or not configured, extensions will not be managed.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#extensionsettings.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/extensionsettings/.</string>
       <string id="ExtensionSettingsOneLine">Extension Management (JSON on one line)</string>
       <string id="HardwareAcceleration">Hardware Acceleration</string>
       <string id="HardwareAcceleration_Explain">If this policy is disabled, hardware acceleration is disabled and cannot be enabled.
@@ -1009,7 +1009,7 @@ If this policy is not configured, the user can choose to create a primary passwo
 
 If this policy is disabled or not configured, Firefox defaults are used.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#handlers.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/handlers/.</string>
       <string id="PreferencesOneLine">Preferences (JSON on one line)</string>
       <string id="Preferences">Preferences</string>
       <string id="Preferences_Explain">Note: In order to use this policy, you must clear all settings in the old Preferences (Deprecated) section.
@@ -1018,7 +1018,7 @@ If this policy is enabled, you can use JSON to configure preferences.
 
 If this policy is disabled or not configured, preferences are not modified.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/preferences/.</string>
       <string id="BookmarksOneLine">Bookmarks (JSON on one line)</string>
       <string id="Bookmarks">Bookmarks (JSON)</string>
       <string id="Bookmarks_Explain">If this policy is enabled, you can use JSON to configure bookmarks, including [] to clear all bookmarks.
@@ -1029,14 +1029,14 @@ If this policy is enabled along with individual bookmarks, those bookmarks will 
 
 This policy has no effect on Managed Bookmarks.
 
-For detailed information on the JSON, see https://github.com/mozilla/policy-templates/blob/master/README.md#bookmarks.</string>
+For detailed information on the JSON, see https://firefox-admin-docs.mozilla.org/reference/policies/bookmarks/.</string>
       <string id="ManagedBookmarksOneLine">Managed Bookmarks (JSON on one line)</string>
       <string id="ManagedBookmarks">Managed Bookmarks</string>
       <string id="ManagedBookmarks_Explain">If this policy is enabled, you can use JSON to configure managed bookmarks.
 
 If this policy is disabled or not configured, managed bookmarks are not added.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#managedbookmarks.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/managedbookmarks/.</string>
       <string id="AllowedDomainsForApps">Define domains allowed to access Google Workspace</string>
       <string id="AllowedDomainsForApps_Explain">If this policy is enabled, the user can only access Google Workspace for the specified domains (separated by a comma). To allow access to Gmail, you can add consumer_accounts.
 
@@ -1051,7 +1051,7 @@ If this policy is enabled or not configured, application updates may be installe
 
 If this policy is disabled or not configured, any site that invokes an external protocol will ask the user for permission.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#autolaunchprotocolsfromorigins.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/autolaunchprotocolsfromorigins/.</string>
       <string id="WindowsSSO">Windows SSO</string>
       <string id="WindowsSSO_Explain">If this policy is enabled, Firefox will use credentials stored in Windows to sign in to Microsoft, work, and school accounts.
 
@@ -1066,7 +1066,7 @@ If this policy is disabled or not configured, Firefox will show print preview be
 
 If this policy is disabled or not configured, warnings are shown for all executable file types.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#exemptdomainfiletypepairsfromfiletypedownloadwarnings.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/exemptdomainfiletypepairsfromfiletypedownloadwarnings/.</string>
       <string id="StartDownloadsInTempDirectory">Start Downloads in Temporary Directory</string>
       <string id="StartDownloadsInTempDirectory_Explain">If this policy is enabled, Firefox will start downloads in a temporary directory and they will be automatically deleted when you close the browser.
 
@@ -1131,7 +1131,7 @@ If this policy is disabled or not configured, the user is allowed to block third
 
 If this policy is disabled or not configured, the built-in defaults are used.
 
-For detailed information on creating the policy, see https://github.com/mozilla/policy-templates/blob/master/README.md#containers.</string>
+For detailed information on creating the policy, see https://firefox-admin-docs.mozilla.org/reference/policies/containers/.</string>
       <string id="FirefoxSuggest_WebSuggestions">Suggestions from the web</string>
       <string id="FirefoxSuggest_WebSuggestions_Explain">If this policy is enabled, you will get suggestions from Firefox related to your search.
 
@@ -1483,17 +1483,17 @@ If this policy is disabled or not configured, the user can change Local Network 
 
 For a description of the preference, see:
 
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/</string>
       <string id="Preferences_String_Explain">If this policy is enabled, the preference is locked to the string entered. If this policy is disabled, it has no effect.
 
 For a description of the preference, see:
 
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/</string>
       <string id="Preferences_Enum_Explain">If this policy is enabled, the preference is locked to the value selected. If this policy is disabled, it has no effect.
 
 For a description of the preference, see:
 
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/.</string>
       <string id="Preferences_Unsupported_Explain">This preference is no longer supported on Windows. We are investigating creating a policy.</string>
       <string id="Preferences_accessibility_force_disabled_auto">Auto (0)</string>
       <string id="Preferences_accessibility_force_disabled_off">Always Off (1)</string>

--- a/windows/fr-FR/firefox.adml
+++ b/windows/fr-FR/firefox.adml
@@ -385,7 +385,7 @@ Si cette stratégie est activée ou non configurée, les extensions seront mises
 
 Si cette stratégie est désactivée ou non configurée, les extensions ne seront pas gérées.
 
-Pour plus d'informations sur la création de la stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#extensionsettings.</string>
+Pour plus d'informations sur la création de la stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/extensionsettings/.</string>
       <string id="ExtensionSettingsOneLine">Gestion des extensions (JSON sur une seule ligne)</string>
       <string id="HardwareAcceleration">Accélération matérielle</string>
       <string id="HardwareAcceleration_Explain">Si cette stratégie est désactivée, l'accélération matérielle est désactivée et ne peut pas être activée.
@@ -1009,7 +1009,7 @@ Si cette stratégie n'est pas configurée, les utilisateurs peuvent choisir de c
 
 Si cette stratégie est désactivée ou non configurée, les paramètres par défaut de Firefox sont utilisés.
 
-Pour des informations détaillées sur la création de cette stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#handlers.</string>
+Pour des informations détaillées sur la création de cette stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/handlers/.</string>
       <string id="PreferencesOneLine">Préférences (JSON sur une seule ligne)</string>
       <string id="Preferences">Préférences</string>
       <string id="Preferences_Explain">Note : Pour utiliser cette stratégie, vous devez supprimer tous les paramètres dans l'ancienne section Préférences (Obsolète).
@@ -1018,7 +1018,7 @@ Si cette stratégie est activée, vous pouvez utiliser JSON pour configurer les 
 
 Si cette stratégie est désactivée ou non configurée, les préférences ne sont pas modifiées.
 
-Pour des informations détaillées sur la création de cette stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</string>
+Pour des informations détaillées sur la création de cette stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/preferences/.</string>
       <string id="BookmarksOneLine">Favoris (JSON sur une seule ligne)</string>
       <string id="Bookmarks">Favoris (JSON)</string>
       <string id="Bookmarks_Explain">Si cette stratégie est activée, vous pouvez utiliser JSON pour configurer les favoris, y compris [] pour effacer tous les favoris.
@@ -1029,14 +1029,14 @@ Si cette stratégie est activée en même temps que des favoris individuels, ces
 
 Cette stratégie n'a aucun effet sur les favoris gérés.
 
-Pour des informations détaillées sur le JSON, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#bookmarks.</string>
+Pour des informations détaillées sur le JSON, consultez https://firefox-admin-docs.mozilla.org/reference/policies/bookmarks/.</string>
       <string id="ManagedBookmarksOneLine">Favoris gérés (JSON sur une seule ligne)</string>
       <string id="ManagedBookmarks">Favoris gérés</string>
       <string id="ManagedBookmarks_Explain">Si cette stratégie est activée, vous pouvez utiliser JSON pour configurer les favoris gérés.
 
 Si cette stratégie est désactivée ou non configurée, les favoris gérés ne sont pas ajoutés.
 
-Pour des informations détaillées sur la création de cette stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#managedbookmarks.</string>
+Pour des informations détaillées sur la création de cette stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/managedbookmarks/.</string>
       <string id="AllowedDomainsForApps">Définir les domaines autorisés à accéder à Google Workspace</string>
       <string id="AllowedDomainsForApps_Explain">Si cette stratégie est activée, les utilisateurs ne peuvent accéder à Google Workspace que pour les domaines spécifiés (séparés par une virgule). Pour permettre l'accès à Gmail, vous pouvez ajouter consumer_accounts.
 
@@ -1051,7 +1051,7 @@ Si cette stratégie est activée ou non configurée, les mises à jour de l'appl
 
 Si cette stratégie est désactivée ou non configurée, tout site qui invoque un protocole externe demandera l'autorisation de l'utilisateur.
 
-Pour des informations détaillées sur la création de cette stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#autolaunchprotocolsfromorigins.</string>
+Pour des informations détaillées sur la création de cette stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/autolaunchprotocolsfromorigins/.</string>
       <string id="WindowsSSO">SSO Windows</string>
       <string id="WindowsSSO_Explain">Si cette stratégie est activée, Firefox utilisera les identifiants stockés dans Windows pour se connecter aux comptes Microsoft, professionnels et scolaires.
 
@@ -1066,7 +1066,7 @@ Si cette stratégie est désactivée ou non configurée, Firefox affichera l'ape
 
 Si cette stratégie est désactivée ou non configurée, des avertissements seront affichés pour tous les types de fichiers exécutables.
 
-Pour des informations détaillées sur la création de cette stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#exemptdomainfiletypepairsfromfiletypedownloadwarnings.</string>
+Pour des informations détaillées sur la création de cette stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/exemptdomainfiletypepairsfromfiletypedownloadwarnings/.</string>
       <string id="StartDownloadsInTempDirectory">Démarrer les téléchargements dans un répertoire temporaire</string>
       <string id="StartDownloadsInTempDirectory_Explain">Si cette stratégie est activée, Firefox commencera les téléchargements dans un répertoire temporaire et les supprimera automatiquement lorsque vous fermerez le navigateur.
 
@@ -1131,7 +1131,7 @@ Si cette stratégie est désactivée ou non configurée, les utilisateurs peuven
 
 Si cette stratégie est désactivée ou non configurée, les paramètres par défaut intégrés sont utilisés.
 
-Pour des informations détaillées sur la création de cette stratégie, consultez https://github.com/mozilla/policy-templates/blob/master/README.md#containers.</string>
+Pour des informations détaillées sur la création de cette stratégie, consultez https://firefox-admin-docs.mozilla.org/reference/policies/containers/.</string>
       <string id="FirefoxSuggest_WebSuggestions">Suggestions du web</string>
       <string id="FirefoxSuggest_WebSuggestions_Explain">Si cette stratégie est activée, vous recevrez des suggestions de Firefox liées à votre recherche.
 
@@ -1490,17 +1490,17 @@ Si cette stratégie est désactivée ou non configurée, l’utilisateur peut mo
 
 Pour une description de la préférence, consultez :
 
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/</string>
       <string id="Preferences_String_Explain">Si cette stratégie est activée, la préférence est verrouillée sur la chaîne de caractères saisie. Si cette stratégie est désactivée, elle n'a aucun effet.
 
 Pour une description de la préférence, consultez :
 
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/</string>
       <string id="Preferences_Enum_Explain">Si cette stratégie est activée, la préférence est verrouillée sur la valeur sélectionnée. Si cette stratégie est désactivée, elle n'a aucun effet.
 
 Pour une description de la préférence, consultez :
 
-https://github.com/mozilla/policy-templates/blob/master/README.md#preferences.</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/.</string>
       <string id="Preferences_Unsupported_Explain">Cette préférence n'est plus prise en charge sur Windows. Nous étudions la création d'une politique à ce sujet.</string>
       <string id="Preferences_accessibility_force_disabled_auto">Automatique (0)</string>
       <string id="Preferences_accessibility_force_disabled_off">Toujours désactivé (1)</string>

--- a/windows/ru-RU/firefox.adml
+++ b/windows/ru-RU/firefox.adml
@@ -387,7 +387,7 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Если эта политика отключена или не настроена, расширения не будут управляться.
 
-Для получения подробной информации о создании политики см. https://mozilla.github.io/policy-templates/#extensions.</string>
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/extensionsettings/.</string>
       <string id="HardwareAcceleration">Аппаратное ускорение</string>
       <string id="HardwareAcceleration_Explain">Если эта политика отключена, аппаратное ускорение не может быть включено.
 
@@ -1012,7 +1012,7 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Если эта политика отключена или не настроена, используются настройки Firefox по умолчанию.
 
-Для получения подробной информации о создании политики см. https://mozilla.github.io/policy-templates/#handlers.</string>
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/handlers/.</string>
       <string id="PreferencesOneLine">Настройки (JSON on one line)</string>
       <string id="Preferences">Настройки</string>
       <string id="Preferences_Explain">Примечание. Чтобы использовать эту политику, необходимо очистить все настройки в старом разделе настроек (устарело).
@@ -1021,7 +1021,7 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Если эта политика отключена или не настроена, предпочтения не изменяются.
 
-Для получения подробной информации о создании политики см. https://mozilla.github.io/policy-templates/#preferences.</string>
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/preferences/.</string>
       <string id="BookmarksOneLine">Закладки (JSON on one line)</string>
       <string id="Bookmarks">Закладки (JSON)</string>
       <string id="Bookmarks_Explain">Если эта политика включена, вы можете использовать JSON для настройки закладок, в том числе [] для удаления всех закладок.
@@ -1032,14 +1032,14 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Эта политика не влияет на управляемые закладки.
 
-Для получения подробной информации о JSON см. https://mozilla.github.io/policy-templates/#bookmarks.</string>
+Для получения подробной информации о JSON см. https://firefox-admin-docs.mozilla.org/reference/policies/bookmarks/.</string>
       <string id="ManagedBookmarksOneLine">Управляемые закладки (JSON on one line)</string>
       <string id="ManagedBookmarks">Управляемые закладки</string>
       <string id="ManagedBookmarks_Explain">Если эта политика включена, вы можете использовать JSON для настройки управляемых закладок.
 
 Если эта политика отключена или не настроена, управляемые закладки не добавляются.
 
-Для получения подробной информации о создании политики см. https://mozilla.github.io/policy-templates/#managedbookmarks.</string>
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/managedbookmarks/.</string>
       <string id="AllowedDomainsForApps">Определить домены, которым разрешен доступ к Google Workspace</string>
       <string id="AllowedDomainsForApps_Explain">Если эта политика включена, пользователи могут получить доступ к Google Workspace только для указанных доменов (разделенных запятой). Чтобы разрешить доступ к Gmail, вы можете добавить Consumer_accounts.
 
@@ -1054,7 +1054,7 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Если эта политика отключена или не настроена, любой сайт, который вызывает внешний протокол, будет запрашивать у пользователя разрешение.
 
-Для получения подробной информации о создании политики см. https://mozilla.github.io/policy-templates/#autolaunchprotocolsfromorigins.</string>
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/autolaunchprotocolsfromorigins/.</string>
       <string id="WindowsSSO">Windows SSO (единый вход)</string>
       <string id="WindowsSSO_Explain">Если эта политика включена, Firefox будет использовать единый вход Windows для учётных записей Microsoft, учётных записей на работе и в учебных заведениях.
 
@@ -1069,7 +1069,7 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Если эта политика отключена или не настроена, предупреждения отображаются для всех типов исполняемых файлов.
 
-Для получения подробной информации о создании политики см. https://mozilla.github.io/policy-templates/#exemptdomainfiletypepairsfromfiletypedownloadwarnings.</string>
+Для получения подробной информации о создании политики см. https://firefox-admin-docs.mozilla.org/reference/policies/exemptdomainfiletypepairsfromfiletypedownloadwarnings/.</string>
       <string id="StartDownloadsInTempDirectory">Начать загрузку во временном каталоге</string>
       <string id="StartDownloadsInTempDirectory_Explain">Если эта политика включена, Firefox начнет загрузку во временный каталог и автоматически удалит её при закрытии браузера.
 
@@ -1134,7 +1134,7 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Если эта политика отключена или не настроена, используются встроенные значения по умолчанию.
 
-Подробную информацию о создании политики см. на странице https://mozilla.github.io/policy-templates/#containers.</string>
+Подробную информацию о создании политики см. на странице https://firefox-admin-docs.mozilla.org/reference/policies/containers/.</string>
       <string id="FirefoxSuggest_WebSuggestions">Предложения из Интернета</string>
       <string id="FirefoxSuggest_WebSuggestions_Explain">Если эта политика включена, вы будете получать предложения от Firefox, связанные с вашим поиском.
 
@@ -1485,17 +1485,17 @@ Mozilla рекомендует не отключать телеметрию. И�
 
 Описание предпочтения см.:
 
-https://mozilla.github.io/policy-templates/#preferences</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/</string>
       <string id="Preferences_String_Explain">Если эта политика включена, предпочтение привязано к введенной строке. Если эта политика отключена, она не действует.
 
 Описание предпочтения см.:
 
-https://mozilla.github.io/policy-templates/#preferences</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/</string>
       <string id="Preferences_Enum_Explain">Если эта политика включена, предпочтение привязано к выбранному значению. Если эта политика отключена, она не действует.
 
 Описание предпочтения см.:
 
-https://mozilla.github.io/policy-templates/#preferences.</string>
+https://firefox-admin-docs.mozilla.org/reference/policies/preferences/.</string>
       <string id="Preferences_Unsupported_Explain">Это предпочтение больше не поддерживается в Windows. Мы изучаем возможность создания политики.</string>
       <string id="Preferences_accessibility_force_disabled_auto">Автоматически (0)</string>
       <string id="Preferences_accessibility_force_disabled_off">Всегда выключено (1)</string>


### PR DESCRIPTION
Retargets the doc links embedded in the ADML explain text at the current documentation
site.

All 44 links across the four ADMLs pointed at URLs that are going away with
`docs/index.md`:

- `github.com/mozilla/policy-templates/blob/master/README.md#<anchor>` — en-US, de-DE, fr-FR
- `mozilla.github.io/policy-templates/#<anchor>` — ru-RU

They now point at `firefox-admin-docs.mozilla.org/reference/policies/<policy>/`, the same
base `scripts/generate_oma_uris.py` already emits for `docs/oma-uris.md`.

### Affected policies

`AutoLaunchProtocolsFromOrigins`, `Bookmarks`, `Containers`,
`ExemptDomainFileTypePairsFromFileTypeDownloadWarnings`, `ExtensionSettings`, `Handlers`,
`ManagedBookmarks`, `Preferences` — 11 links in each locale, symmetric across all four.

### Drive-by fix

ru-RU's `ExtensionSettings_Explain` linked to the `Extensions` anchor rather than
`ExtensionSettings`, where the other three locales correctly used `#extensionsettings`.
Now consistent.

### Verification

- All four ADMLs parse as XML.
- No `mozilla.github.io/policy-templates` or `policy-templates/blob/master/README`
  references remain anywhere in the repo.
- All eight distinct target URLs return HTTP 200. The docs site returns real 404s for
  unknown paths (verified against a bogus path), so those 200s are meaningful rather than
  soft-404s.
- Only the URLs changed — the surrounding sentence in each locale is untouched, including
  the three distinct ru-RU phrasings.

No ADMX change, so no `revision` bump is implied here.
