### PR TITLE
Move the release tag to the version-bump commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,20 @@ jobs:
           git diff --staged --quiet || git commit -m "Bump version to ${{ steps.version.outputs.version }}"
           git push origin HEAD:master
 
+      # The tag triggers this workflow, so the bump commit is necessarily a child
+      # of the tagged commit - meaning the tag's own tree would still carry the
+      # previous release's revision numbers. Re-point the tag at the bump commit
+      # so browsing the repo at the tag shows the revision that tag released.
+      # HEAD is a direct descendant of the original tag, so nothing is lost.
+      #
+      # This does not retrigger the workflow: GitHub does not start new runs for
+      # pushes made with the default GITHUB_TOKEN. If this is ever switched to a
+      # PAT, this step becomes an infinite loop.
+      - name: Move tag to the version-bump commit
+        run: |
+          git tag -f "$GITHUB_REF_NAME" HEAD
+          git push --force origin "refs/tags/$GITHUB_REF_NAME"
+
       - name: Create release ZIP
         run: |
           zip -r "policy_templates_${GITHUB_REF_NAME}.zip" docs/ mac/ windows/ linux/ LICENSE


### PR DESCRIPTION
The tag is what triggers `release.yml`, so the version-bump commit the workflow creates is
necessarily a *child* of the tagged commit. That means every tag's own tree still carries
the previous release's revision numbers, and the regenerated `docs/oma-uris.md` isn't in
the tag at all:

| Tag | `revision` in its own tree |
| --- | --- |
| `v8.1` | `8.0` |
| `v8.0` | `7.12` |
| `v7.12` | `7.11` |

The release ZIP has always been correct — it's built after the bump — but browsing the repo
at a tag showed the wrong version, which is confusing when checking what a release actually
contained.

### Fix

After committing the bump, re-point the tag at that commit:

```yaml
- name: Move tag to the version-bump commit
  run: |
    git tag -f "$GITHUB_REF_NAME" HEAD
    git push --force origin "refs/tags/$GITHUB_REF_NAME"
```

`HEAD` is a direct descendant of the original tagged commit, so no content is lost — the
tag only moves forward. The step runs before `gh release create`, so the release binds to
the corrected commit.

### Why this doesn't loop

Force-pushing a tag is a tag push, which would normally match this workflow's
`on: push: tags` trigger. GitHub suppresses workflow runs for pushes made with the default
`GITHUB_TOKEN`, so it won't retrigger. That's called out in an inline comment, because
switching this workflow to a PAT would silently turn it into an infinite loop.

### Note on existing tags

This only affects releases from here on. Existing tags are left alone.
