### PR TITLE
Add DisableLaunchOnLogin policy

### DIFF
--- a/mac/org.mozilla.firefox.plist
+++ b/mac/org.mozilla.firefox.plist
@@ -259,6 +259,8 @@
 	<true/>
 	<key>DisableFormHistory</key>
 	<true/>
+	<key>DisableLaunchOnLogin</key>
+	<true/>
 	<key>DisableMasterPasswordCreation</key>
 	<true/>
 	<key>DisablePasswordReveal</key>

--- a/windows/de-DE/firefox.adml
+++ b/windows/de-DE/firefox.adml
@@ -91,6 +91,7 @@
       <string id="SUPPORTED_FF153_ONLY">Firefox 153 oder höher</string>
       <string id="SUPPORTED_FF154_ONLY">Firefox 154 oder höher</string>
       <string id="SUPPORTED_FF154">Firefox 154 oder höher, Firefox 153 ESR oder höher</string>
+      <string id="SUPPORTED_FF155_ONLY">Firefox 155 oder höher</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Berechtigungen</string>
       <string id="Camera_group">Kamera</string>
@@ -293,6 +294,10 @@ Wenn Sie die Richtlinieneinstellung deaktivieren oder nicht konfigurieren, steht
       <string id="DisableFormHistory_Explain">Wenn Sie die Richtlinieneinstellung aktivieren, wird Firefox keine Formular- oder Suchverläufe speichern.
 
 Wenn Sie die Richtlinieneinstellung deaktivieren oder nicht konfigurieren, wird Firefox Formular- und Suchverläufe speichern.</string>
+      <string id="DisableLaunchOnLogin">Start bei Anmeldung deaktivieren</string>
+      <string id="DisableLaunchOnLogin_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, wird Firefox nicht automatisch gestartet, wenn sich der Benutzer anmeldet. Ein vorhandener Eintrag für den Start bei der Anmeldung wird entfernt und das Kontrollkästchen „Firefox automatisch beim Start des Computers öffnen“ unter „Einstellungen > Allgemein > Beim Start“ wird ausgeblendet.
+
+Wenn diese Richtlinieneinstellung deaktiviert oder nicht konfiguriert ist, steuert der Benutzer, ob Firefox bei der Anmeldung gestartet wird.</string>
       <string id="DisablePasswordReveal">Verbieten, dass Nutzer Passwörter in Gespeicherte Zugangsdaten anzeigen können</string>
       <string id="DisablePasswordReveal_Explain">Wenn diese Richtlinieneinstellung aktiviert ist, können Nutzer Gespeicherte Zugangsdaten nicht anzeigen lassen.
 

--- a/windows/en-US/firefox.adml
+++ b/windows/en-US/firefox.adml
@@ -91,6 +91,7 @@
       <string id="SUPPORTED_FF153_ONLY">Firefox 153 or later</string>
       <string id="SUPPORTED_FF154_ONLY">Firefox 154 or later</string>
       <string id="SUPPORTED_FF154">Firefox 154 or later, Firefox 153 ESR or later</string>
+      <string id="SUPPORTED_FF155_ONLY">Firefox 155 or later</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Permissions</string>
       <string id="Camera_group">Camera</string>
@@ -293,6 +294,10 @@ If this policy is disabled or not configured, the "Forget" button is available.<
       <string id="DisableFormHistory_Explain">If this policy is enabled, Firefox will not remember form or search history.
 
 If this policy is disabled or not configured, Firefox will remember form and search history.</string>
+      <string id="DisableLaunchOnLogin">Disable launch on login</string>
+      <string id="DisableLaunchOnLogin_Explain">If this policy is enabled, Firefox does not launch automatically when the user logs in. Any existing launch-on-login entry is removed and the "Open Firefox automatically when your computer starts up" checkbox in Settings > General > Startup is hidden.
+
+If this policy is disabled or not configured, the user controls whether Firefox launches on login.</string>
       <string id="DisablePasswordReveal">Do not allow passwords to be revealed in saved logins</string>
       <string id="DisablePasswordReveal_Explain">If this policy is enabled, the user cannot show passwords in saved logins.
 

--- a/windows/firefox.admx
+++ b/windows/firefox.admx
@@ -93,6 +93,7 @@
       <definition name="SUPPORTED_FF153_ONLY" displayName="$(string.SUPPORTED_FF153_ONLY)"/>
       <definition name="SUPPORTED_FF154_ONLY" displayName="$(string.SUPPORTED_FF154_ONLY)"/>
       <definition name="SUPPORTED_FF154" displayName="$(string.SUPPORTED_FF154)"/>
+      <definition name="SUPPORTED_FF155_ONLY" displayName="$(string.SUPPORTED_FF155_ONLY)"/>
     </definitions>
   </supportedOn>
   <categories>
@@ -983,6 +984,16 @@
     <policy name="DisableFormHistory" class="Both" displayName="$(string.DisableFormHistory)" explainText="$(string.DisableFormHistory_Explain)" key="Software\Policies\Mozilla\Firefox" valueName="DisableFormHistory">
       <parentCategory ref="firefox"/>
       <supportedOn ref="SUPPORTED_FF60"/>
+      <enabledValue>
+        <decimal value="1"/>
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0"/>
+      </disabledValue>
+    </policy>
+    <policy name="DisableLaunchOnLogin" class="Both" displayName="$(string.DisableLaunchOnLogin)" explainText="$(string.DisableLaunchOnLogin_Explain)" key="Software\Policies\Mozilla\Firefox" valueName="DisableLaunchOnLogin">
+      <parentCategory ref="firefox"/>
+      <supportedOn ref="SUPPORTED_FF155_ONLY"/>
       <enabledValue>
         <decimal value="1"/>
       </enabledValue>

--- a/windows/fr-FR/firefox.adml
+++ b/windows/fr-FR/firefox.adml
@@ -91,6 +91,7 @@
       <string id="SUPPORTED_FF153_ONLY">Firefox 153 ou supérieur</string>
       <string id="SUPPORTED_FF154_ONLY">Firefox 154 ou supérieur</string>
       <string id="SUPPORTED_FF154">Firefox 154 ou supérieur, Firefox 153 ESR ou supérieur</string>
+      <string id="SUPPORTED_FF155_ONLY">Firefox 155 ou supérieur</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Permissions</string>
       <string id="Camera_group">Caméra</string>
@@ -293,6 +294,10 @@ Si cette stratégie est désactivée ou non configurée, le bouton "Forget" est 
       <string id="DisableFormHistory_Explain">Si cette stratégie est activée, Firefox ne conservera pas l'historique du formulaire ou de la recherche.
 
 Si cette stratégie est désactivée ou non configurée, Firefox conservera l'historique des formulaires et des recherches.</string>
+      <string id="DisableLaunchOnLogin">Désactiver le lancement à la connexion</string>
+      <string id="DisableLaunchOnLogin_Explain">Si cette stratégie est activée, Firefox ne se lance pas automatiquement lorsque l’utilisateur se connecte. Toute entrée de lancement à la connexion existante est supprimée et la case « Ouvrir Firefox automatiquement au démarrage de votre ordinateur » sous « Paramètres > Général > Au démarrage » est masquée.
+
+Si cette stratégie est désactivée ou non configurée, l’utilisateur contrôle le lancement de Firefox à la connexion.</string>
       <string id="DisablePasswordReveal">Ne pas autoriser la révélation des mots de passe dans les connexions enregistrées</string>
       <string id="DisablePasswordReveal_Explain">Si cette stratégie est activée, les utilisateurs ne peuvent pas afficher les mots de passe dans les connexions enregistrées.
 

--- a/windows/ru-RU/firefox.adml
+++ b/windows/ru-RU/firefox.adml
@@ -92,6 +92,7 @@
       <string id="SUPPORTED_FF153_ONLY">Firefox 153 или более поздние версии</string>
       <string id="SUPPORTED_FF154_ONLY">Firefox 154 или более поздние версии</string>
       <string id="SUPPORTED_FF154">Firefox 154 или более поздние версии, Firefox 153 ESR или более поздние версии</string>
+      <string id="SUPPORTED_FF155_ONLY">Firefox 155 или более поздние версии</string>
       <string id="firefox">Firefox</string>
       <string id="Permissions_group">Разрешения</string>
       <string id="Camera_group">Камера</string>
@@ -294,6 +295,10 @@
       <string id="DisableFormHistory_Explain">Если эта политика включена, Firefox не запомнит историю форм или поиска.
 
 Если эта политика отключена или не настроена, Firefox запомнит историю форм и поиска.</string>
+      <string id="DisableLaunchOnLogin">Отключить запуск при входе в систему</string>
+      <string id="DisableLaunchOnLogin_Explain">Если эта политика включена, Firefox не запускается автоматически при входе пользователя в систему. Существующая запись о запуске при входе удаляется, а флажок «Открывать Firefox автоматически при запуске компьютера» в разделе «Настройки > Основные > При запуске» скрывается.
+
+Если эта политика отключена или не настроена, пользователь сам определяет, запускается ли Firefox при входе в систему.</string>
       <string id="DisablePasswordReveal">Запретить показывать пароли в сохраненных логинах</string>
       <string id="DisablePasswordReveal_Explain">Если эта политика включена, пользователи не могут отображать пароли в сохраненных логинах.
 


### PR DESCRIPTION
Adds the `DisableLaunchOnLogin` policy. When enabled, Firefox does not start automatically
at login, any existing launch-on-login entry is removed, and the **Open Firefox
automatically when your computer starts up** checkbox under **Settings > General > Startup**
is hidden. Setting it to `false` has no effect, so `false` and unset behave identically —
which the two-branch explain text reflects.

### Version label

Uses `SUPPORTED_FF155_ONLY`, added here since it didn't exist yet. Both the schema and the
[published docs](https://firefox-admin-docs.mozilla.org/reference/policies/disablelaunchonlogin/)
agree there is no ESR backport — Firefox 155, Firefox Enterprise 155, ESR not supported — so
it takes the `_ONLY` form. Only this policy needs the new label, so it lands in this branch
rather than a separate `supported-versions-155` branch.

The new string follows the existing 150–154 phrasing in each locale:

| Locale | String |
| --- | --- |
| en-US | Firefox 155 or later |
| de-DE | Firefox 155 oder höher |
| fr-FR | Firefox 155 ou supérieur |
| ru-RU | Firefox 155 или более поздние версии |

### Checked against the published docs

Reviewing against the docs corrected two things in the original draft of this policy:

- **The explain text claimed the policy is Windows-only.** It applies to Windows (155) and
  macOS (156), so the note is removed. There was no precedent for platform notes in the
  ADML — this would have been the only one — and an ADMX is a Windows artifact by
  definition, so the note was noise regardless.
- **No `linux/policies.json` sample.** The policy has no effect on Linux, and the repo
  already omits Windows-only policies from that sample: `WindowsSSO`,
  `DisableThirdPartyModuleBlocking`, and `DisableDefaultBrowserAgent` are all absent, while
  cross-platform `DisableSetDesktopBackground` is present. The macOS plist entry stays,
  since macOS is supported.

The registry shape (`Software\Policies\Mozilla\Firefox\DisableLaunchOnLogin`, DWORD `1`/`0`)
matches the docs exactly.

### Verification

- All five XML files parse.
- Every `$(string.*)` and `$(presentation.*)` reference in the ADMX resolves in all four
  ADMLs (no orphans), including the new `SUPPORTED_FF155_ONLY`.
- The explain text uses each locale's own two-branch idiom in two paragraphs; none is a copy
  of the English.
- `mac/org.mozilla.firefox.plist` still parses.

### Note on timing

macOS support arrives in Firefox 156, so the macOS plist sample is slightly ahead if this
ships before then. Deliberate, not an oversight.
