### PR TITLE
Build the release from master instead of the tagged commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,25 @@ jobs:
       contents: write
 
     steps:
+      # Check out master rather than the tagged commit. The tag supplies only the
+      # version number; the release is built from master's tip. This makes the
+      # workflow tolerant of a tag pushed before a pull, which would otherwise
+      # leave the bump commit unable to fast-forward into master. The tag is
+      # re-pointed at the resulting commit further down, so tag and release still
+      # agree. Building from master also means docs/oma-uris.md is regenerated
+      # from a tree containing everything merged, not just what the tag saw.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Note if the tag was behind master
+        run: |
+          TAGGED="$(git rev-parse "$GITHUB_REF_NAME^{commit}")"
+          if [ "$TAGGED" != "$(git rev-parse HEAD)" ]; then
+            echo "::warning::Tag $GITHUB_REF_NAME points at $TAGGED but master is at $(git rev-parse HEAD). Releasing master; the tag will be moved to match."
+          fi
 
       - name: Install xmlstarlet
         run: sudo apt-get install -y xmlstarlet
@@ -42,8 +59,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add windows/firefox.admx windows/de-DE/firefox.adml windows/en-US/firefox.adml windows/ru-RU/firefox.adml windows/fr-FR/firefox.adml docs/oma-uris.md
-          git diff --staged --quiet || git commit -m "Bump version to ${{ steps.version.outputs.version }}"
-          git push origin HEAD:master
+          if git diff --staged --quiet; then
+            echo "Revision numbers already current; nothing to commit."
+          else
+            git commit -m "Bump version to ${{ steps.version.outputs.version }}"
+            git push origin HEAD:master
+          fi
 
       # The tag triggers this workflow, so the bump commit is necessarily a child
       # of the tagged commit - meaning the tag's own tree would still carry the


### PR DESCRIPTION
Two releases in a row failed the same way — `v8.1` and `v8.2` — both because a tag was
pushed before pulling, so master had moved on:

```
! [rejected]        HEAD -> master (fetch first)
```

The workflow checks out the *tagged* commit, commits the version bump on top of it, then
pushes that to `master`. If anything landed on master after the tag was created, that push
is a non-fast-forward and the whole release dies two steps from the end — after the bump
commit has already been made locally.

### Fix

Check out `master` instead of the tagged commit. The tag now supplies only the version
number. The bump always fast-forwards, and the move-tag step from #1331 already re-points
the tag at the resulting commit, so the tag and the release still agree afterwards.

### This also fixes a quieter bug

`docs/oma-uris.md` is regenerated from whatever tree is checked out. With the old
behaviour, a tag created before a merge would regenerate the docs from a tree that didn't
contain the newly merged policies — so the shipped ZIP would silently omit them.

**`v8.2` would have shipped without `DisableLaunchOnLogin`** despite #1333 being merged, had
the push succeeded. The failure masked a correctness problem.

A `::warning::` annotation now records when the tag was behind master, so it shows in the
run summary instead of being invisible.

### Also guarded the bump commit

```yaml
if git diff --staged --quiet; then
  echo "Revision numbers already current; nothing to commit."
else
  git commit -m "Bump version to $VERSION"
  git push origin HEAD:master
fi
```

The push previously ran unconditionally, so retagging an already-bumped tree failed even
though there was nothing to do. That's what broke the first `v8.1` retag attempt.

### Trade-off

The release is now built from master's tip rather than the exact tagged commit. In normal
use these are the same, since the tag is cut from master. When they differ, building from
master is the safer of the two: it ships what was actually merged, and the tag is moved to
match rather than left pointing somewhere else.

### Verification

- YAML parses; step order is Checkout → tag-behind check → bump → regenerate → commit →
  move tag → zip → release.
- Checkout uses `ref: master` with `fetch-depth: 0` so the tag is available locally for the
  comparison and the move.
