### PR TITLE
Fill the draft release notes from a template file

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,11 @@
+Information about this release is available in the [Firefox Enterprise Release Notes](https://firefox-admin-docs.mozilla.org/release-notes/).
+
+These templates are compatible with Firefox ESR 140, but they may include policies that are not available in that version. If you need to manage Firefox ESR 140, use **v7.12**.
+
+The policy documentation has officially moved to a dedicated site for Firefox administrators: https://firefox-admin-docs.mozilla.org/
+
+The policy templates will continue to be maintained in this repository.
+
+We have also separated out [OMA-URI documentation](https://github.com/mozilla/policy-templates/blob/master/docs/oma-uris.md) since it's based on the ADMX templates.
+
+Please see [this discussion post](https://github.com/mozilla/policy-templates/discussions/1332) for changes to the policy templates release process.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,5 +90,6 @@ jobs:
         run: |
           gh release create "${GITHUB_REF_NAME}" \
             --title "Firefox Policy Templates Version ${{ steps.version.outputs.version }}" \
+            --notes-file .github/release-notes-template.md \
             --draft \
             "policy_templates_${GITHUB_REF_NAME}.zip"


### PR DESCRIPTION
The draft release was created with the bare tag name as its title (`v8.2`) and an empty
body, so both had to be written by hand every time. That manual step is how the same
information ended up in three places. Now the workflow produces a finished draft and the
only remaining action is to publish.

### Title

```yaml
--title "Firefox Policy Templates Version ${{ steps.version.outputs.version }}"
```

The `version` step strips the leading `v`, so tag `v8.2` gives **Firefox Policy Templates
Version 8.2**.

No Firefox version in the title. Previous releases were titled like *"Policy templates for
Firefox 154 and Firefox ESR 153.1"*, but template releases no longer track the Firefox
schedule, and per [discussion #1332](https://github.com/mozilla/policy-templates/discussions/1332)
there is no need to match a template version to a Firefox version — compatibility is stated
per policy in the **Supported on** field and in the Firefox Admin Docs. Version-matched
titles also implied the bundle was specific to one Firefox release, when the templates are
cumulative and contain every policy back to Firefox 60.

### Notes

```yaml
--notes-file .github/release-notes-template.md
```

The boilerplate now lives in the repo, so it is reviewable and identical every release.

Two deliberate choices in it:

- **Links the `/release-notes/` index, not a per-version page.** A constant body cannot
  contain `/release-notes/version/firefox-155/` — it would go stale the moment it is reused.
  Costs one extra click; never wrong.
- **The OMA-URI link is absolute.** GitHub does not rewrite relative links in a release
  body. Confirmed against the markdown API:

  ```
  [OMA-URI documentation](docs/oma-uris.md)
    ->  <a href="docs/oma-uris.md">OMA-URI documentation</a>
  ```

  On a release page that resolves to `/releases/tag/docs/oma-uris.md` and 404s. **This link
  is broken on v8.1 right now**, so it is worth fixing there too.

The template sits in `.github/` so it is not swept into the release ZIP, which packages
`docs/ mac/ windows/ linux/ LICENSE`.

### Unchanged

The tag argument and the ZIP filename still use `GITHUB_REF_NAME`, so the release is still
created against the tag and the asset is still `policy_templates_v8.2.zip`.

### Verification

- Workflow YAML parses; the `version` step the title depends on is untouched.
- All four URLs in the template return HTTP 200.
- Every markdown link target in the template is absolute.
- No version-specific fragments remain in the template.
